### PR TITLE
Add require to fix 'undefined method delegate' error

### DIFF
--- a/lib/discordrb/events/generic.rb
+++ b/lib/discordrb/events/generic.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module'
+
 module Discordrb::Events
   class Negated
     attr_reader :object


### PR DESCRIPTION
I'm not sure exactly what version of ruby/rails/activeSupport this fixes, but this fixed my environment.
(ruby 2.2.3 and rails 4.2.4)
