### PR TITLE
Add user status, fix members being parsed wrong

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -131,7 +131,6 @@ module Discordrb
 
     private
 
-
     # Register any default event handlers that the end user shouldn't
     # need to worry about implementing
     def add_default_handlers
@@ -144,7 +143,7 @@ module Discordrb
           @users[user_id] = event.user
           cached_user = event.user
         end
-        event.user.instance_exec(event.status) do |status|
+        cached_user.instance_exec(event.status) do |status|
           @status = status
         end
       end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -27,6 +27,8 @@ module Discordrb
 
       @channels = {}
       @users = {}
+
+      add_default_handlers
     end
 
     def run
@@ -128,6 +130,25 @@ module Discordrb
     alias_method :<<, :add_handler
 
     private
+
+
+    # Register any default event handlers that the end user shouldn't
+    # need to worry about implementing
+    def add_default_handlers
+      # Update a user's status
+      presence do |event|
+        user_id = event.user.id
+        cached_user = @users[user_id]
+        if !cached_user
+          # If this is a user we've never seen before, add them
+          @users[user_id] = event.user
+          cached_user = event.user
+        end
+        event.user.instance_exec(event.status) do |status|
+          @status = status
+        end
+      end
+    end
 
     def debug(message)
       puts "[DEBUG @ #{Time.now.to_s}] #{message}" if @debug

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -4,12 +4,6 @@ module Discordrb
   class User
     attr_reader :username, :id, :discriminator, :avatar
 
-    # Is the user muted?
-    attr_reader :mute
-
-    # Is the user deafened?
-    attr_reader :deaf
-
     # Is the user online, offline, or away?
     attr_reader :status
 
@@ -18,17 +12,11 @@ module Discordrb
     def initialize(data, bot)
       @bot = bot
 
-      user_data = data['user']
-      if user_data
-        @username = user_data['username']
-        @id = user_data['id'].to_i
-        @discriminator = user_data['discriminator']
-        @avatar = user_data['avatar']
-      end
-        
-      @mute = data['mute']
-      @deaf = data['deaf']
-
+      @username = data['username']
+      @id = data['id'].to_i
+      @discriminator = data['discriminator']
+      @avatar = data['avatar']
+      
       @status = :offline
     end
 
@@ -119,7 +107,7 @@ module Discordrb
       members_by_id = {}
 
       data['members'].each do |element|
-        user = User.new(element, bot)
+        user = User.new(element['user'], bot)
         @members << user
         members_by_id[user.id] = user
       end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -51,7 +51,7 @@ module Discordrb
   end
 
   class Channel
-    attr_reader :name, :server, :type, :id, :is_private, :recipient
+    attr_reader :name, :server, :type, :id, :is_private, :recipient, :topic
 
     def initialize(data, bot)
       @bot = bot
@@ -59,8 +59,9 @@ module Discordrb
       #data is a sometimes a Hash and othertimes an array of Hashes, you only want the last one if it's an array
       data = data[-1] if data.is_a?(Array)
 
-      @id = data['id']
+      @id = data['id'].to_i
       @type = data['type'] || 'text'
+      @topic = data['topic']
 
       @is_private = data['is_private']
       if @is_private


### PR DESCRIPTION
### Fix ###

Server members were not being parsed correctly. This has been fixed.

### Enhancements ###

- Added User#status and populated it automatically while initializing a server.
- Added a default handler for the presence event to automatically update user statuses.
- Added Server#channels.
- Added Channel#topic.