### PR TITLE
Support for new events

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -142,6 +142,19 @@ module Discordrb
     def channel_delete(attributes = {}, &block)
       register_event(ChannelDeleteEvent, attributes, block)
     end
+    
+    # Handle a change to a voice state.
+    # This includes joining a voice channel or changing mute or deaf state.
+    # Attributes:
+    # * from: User whose voice state changed
+    # * mute: server mute status
+    # * deaf: server deaf status
+    # * self_mute: self mute status
+    # * self_deaf: self deaf status
+    # * channel: channel the user joined
+    def voice_state_update(attributes = {}, &block)
+      register_event(VoiceStateUpdateEvent, attributes, block)
+    end
 
     def remove_handler(handler)
       clazz = event_class(handler.class)
@@ -170,14 +183,7 @@ module Discordrb
       end
       
       status = data['status'].to_sym
-      if status == :offline
-        # Remove this user from our cache
-        #@users.reject! {|u| u.id == user.id }
-      else
-        # Make sure the user is cached and in the members list
-        #if !(@users.find {|u| u.id == user.id })
-        #  @users << user
-        #end
+      if status != :offline
         if !(server.members.find {|u| u.id == user.id })
           server.members << user
         end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -4,12 +4,6 @@ module Discordrb
   class User
     attr_reader :username, :id, :discriminator, :avatar
     
-    # Is the member muted?
-    attr_reader :mute
-
-    # Is the member deafened?
-    attr_reader :deaf
-    
     attr_accessor :status
     attr_accessor :game_id
     attr_accessor :server_mute

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -134,7 +134,7 @@ module Discordrb
       @name = data['name']
       @owner_id = data['owner_id'].to_i
       @id = data['id'].to_i
-
+      
       @members = []
       members_by_id = {}
 
@@ -159,10 +159,13 @@ module Discordrb
       end
       
       @channels = []
+      channels_by_id = {}
 
       if data['channels']
         data['channels'].each do |element|
-          @channels << Channel.new(element, bot, self)
+          channel = Channel.new(element, bot, self)
+          @channels << channel
+          channels_by_id[channel.id] = channel
         end
       end
       
@@ -178,7 +181,7 @@ module Discordrb
             channel_id = element['channel_id']
             channel = nil
             if channel_id
-              channel = @channels.find {|c| c.id == channel_id.to_i }
+              channel = channels_by_id[channel_id]
             end
             user.move(channel)
           end

--- a/lib/discordrb/events/channel-create.rb
+++ b/lib/discordrb/events/channel-create.rb
@@ -1,0 +1,48 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class ChannelCreateEvent
+    attr_reader :type
+    attr_reader :topic
+    attr_reader :position
+    attr_reader :name
+    attr_reader :is_private
+    attr_reader :id
+    attr_reader :server
+
+    def initialize(data, bot)
+      @type = data['type']
+      @topic = data['topic']
+      @position = data['position']
+      @name = data['name']
+      @is_private = data['is_private']
+      @id = data['id']
+      @server = bot.server(data['guild_id'].to_i)
+    end
+  end
+
+  class ChannelCreateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? VoiceStateUpdateEvent
+
+      return [
+        matches_all(@attributes[:type], event.type) do |a,e|
+          if a.is_a? String
+            a == e.name
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/channel-delete.rb
+++ b/lib/discordrb/events/channel-delete.rb
@@ -1,0 +1,49 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class ChannelDeleteEvent
+    attr_reader :type
+    attr_reader :topic
+    attr_reader :position
+    attr_reader :name
+    attr_reader :is_private
+    attr_reader :channel
+    attr_reader :server
+
+    def initialize(data, bot)
+      @type = data['type']
+      @topic = data['topic']
+      @position = data['position']
+      @name = data['name']
+      @is_private = data['is_private']
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      @channel = @server.channels.find {|channel| channel.id == data['id'].to_i }
+    end
+  end
+
+  class ChannelDeleteEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? VoiceStateUpdateEvent
+
+      return [
+        matches_all(@attributes[:type], event.type) do |a,e|
+          if a.is_a? String
+            a == e.name
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/channel-delete.rb
+++ b/lib/discordrb/events/channel-delete.rb
@@ -19,7 +19,7 @@ module Discordrb::Events
       @is_private = data['is_private']
       @server = bot.server(data['guild_id'].to_i)
       return if !@server
-      @channel = @server.channels.find {|channel| channel.id == data['id'].to_i }
+      @channel = bot.channel(data['id'].to_i)
     end
   end
 

--- a/lib/discordrb/events/channel-update.rb
+++ b/lib/discordrb/events/channel-update.rb
@@ -1,0 +1,49 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class ChannelUpdateEvent
+    attr_reader :type
+    attr_reader :topic
+    attr_reader :position
+    attr_reader :name
+    attr_reader :is_private
+    attr_reader :channel
+    attr_reader :server
+
+    def initialize(data, bot)
+      @type = data['type']
+      @topic = data['topic']
+      @position = data['position']
+      @name = data['name']
+      @is_private = data['is_private']
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      @channel = @server.channels.find {|channel| channel.id == data['id'].to_i }
+    end
+  end
+
+  class ChannelUpdateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? VoiceStateUpdateEvent
+
+      return [
+        matches_all(@attributes[:type], event.type) do |a,e|
+          if a.is_a? String
+            a == e.name
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/channel-update.rb
+++ b/lib/discordrb/events/channel-update.rb
@@ -19,7 +19,7 @@ module Discordrb::Events
       @is_private = data['is_private']
       @server = bot.server(data['guild_id'].to_i)
       return if !@server
-      @channel = @server.channels.find {|channel| channel.id == data['id'].to_i }
+      @channel = bot.channel(data['id'].to_i)
     end
   end
 

--- a/lib/discordrb/events/voice-state-update.rb
+++ b/lib/discordrb/events/voice-state-update.rb
@@ -1,0 +1,89 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class VoiceStateUpdateEvent
+    attr_reader :user
+    attr_reader :token
+    attr_reader :suppress
+    attr_reader :session_id
+    attr_reader :self_mute
+    attr_reader :self_deaf
+    attr_reader :mute
+    attr_reader :deaf
+    attr_reader :server
+    attr_reader :channel
+
+    def initialize(data, bot)
+      @token = data['token']
+      @suppress = data['suppress']
+      @session_id = data['session_id']
+      @self_mute = data['self_mute']
+      @self_deaf = data['self_deaf']
+      @mute = data['mute']
+      @deaf = data['deaf']
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      if data['channel_id']
+        @channel = @server.channels.find {|channel| channel.id == data['channel_id'].to_i }
+      end
+      @user = @server.members.find {|user| user.id == data['user_id'].to_i }
+    end
+  end
+
+  class VoiceStateUpdateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? VoiceStateUpdateEvent
+
+      return [
+        matches_all(@attributes[:from], event.user) do |a,e|
+          if a.is_a? String
+            a == e.name
+          elsif a.is_a? Fixnum
+            a == e.id
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:mute], event.mute) do |a,e|
+          if a.is_a? Boolean
+            a == e.to_s
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:deaf], event.deaf) do |a,e|
+          if a.is_a? Boolean
+            a == e.to_s
+          else
+            a == e
+          end          
+        end,
+        matches_all(@attributes[:self_mute], event.self_mute) do |a,e|
+          if a.is_a? Boolean
+            a == e.to_s
+          else
+            a == e
+          end
+        end,
+        matches_all(@attributes[:self_deaf], event.self_deaf) do |a,e|
+          if a.is_a? Boolean
+            a == e.to_s
+          else
+            a == e
+          end          
+        end,
+        matches_all(@attributes[:channel], event.channel) do |a,e|
+          if a.is_a? String
+            a == e.name
+          elsif a.is_a? Fixnum
+            a == e.id
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/voice-state-update.rb
+++ b/lib/discordrb/events/voice-state-update.rb
@@ -25,9 +25,9 @@ module Discordrb::Events
       @server = bot.server(data['guild_id'].to_i)
       return if !@server
       if data['channel_id']
-        @channel = @server.channels.find {|channel| channel.id == data['channel_id'].to_i }
+        @channel = bot.channel(data['channel_id'].to_i)
       end
-      @user = @server.members.find {|user| user.id == data['user_id'].to_i }
+      @user = bot.user(data['user_id'].to_i)
     end
   end
 


### PR DESCRIPTION
I made a bunch of changes here. See the first commit message for the overall summary.

Notably, I've added some structure to the relationship between servers, users, and channels and added the infrastructure to keep those relationships up to date as users and channels come and go.

Each server contains a set of users and channels. Users are always present in all text channels (this is an assumption that may not hold when we support permissions), and may be present in only one voice channel at a time. I think I've interpreted Discord correctly, but without an official API it's hard to be sure.

Let me know if you have questions, comments, or spot any bugs!