### PR TITLE
Basic support for roles and permissions, bug fixes

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -360,8 +360,7 @@ module Discordrb
         @heartbeat_active = true
         debug("Desired heartbeat_interval: #{@heartbeat_interval}")
 
-        # Initialize the bot user
-        @bot_user = User.new(data['user'], self)
+        bot_user_id = data['user']['id'].to_i
 
         # Initialize servers
         @servers = {}
@@ -373,6 +372,9 @@ module Discordrb
           server.members.each do |element|
             @users[element.id] = element
           end
+          
+          # Save the bot user
+          @bot_user = @users[bot_user_id]
         end
 
         # Add private channels

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -12,6 +12,10 @@ require 'discordrb/events/voice-state-update'
 require 'discordrb/events/channel-create'
 require 'discordrb/events/channel-update'
 require 'discordrb/events/channel-delete'
+require 'discordrb/events/guild-member-update'
+require 'discordrb/events/guild-role-create'
+require 'discordrb/events/guild-role-delete'
+require 'discordrb/events/guild-role-update'
 
 require 'discordrb/exceptions'
 require 'discordrb/data'
@@ -238,6 +242,49 @@ module Discordrb
       @channels[channel.id] = nil
       server.channels.reject! {|c| c.id == channel.id}
     end
+    
+    # Internal handler for GUILD_MEMBER_UPDATE
+    def update_guild_member(data)
+      user_data = data['user']
+      server_id = data['guild_id'].to_i
+      roles = []
+      data['roles'].each do |element|
+        role_id = element.to_i
+        roles << @servers[server_id].roles.find {|r| r.id == role_id}
+      end
+      user_id = user_data['id'].to_i
+      user = @users[user_id]
+      user.update_roles(roles)
+    end
+    
+    # Internal handler for GUILD_ROLE_UPDATE
+    def update_guild_role(data)
+      role_data = data['role']
+      server_id = data['guild_id'].to_i
+      server = @servers[server_id]
+      new_role = Role.new(role_data, self, server)
+      role_id = role_data['id'].to_i
+      old_role = server.roles.find {|r| r.id == role_id}
+      old_role.update_from(new_role)
+    end
+    
+    # Internal handler for GUILD_ROLE_CREATE
+    def create_guild_role(data)
+      role_data = data['role']
+      server_id = data['guild_id'].to_i
+      server = @servers[server_id]
+      new_role = Role.new(role_data, self, server)
+      server.add_role(new_role)
+    end
+    
+    # Internal handler for GUILD_ROLE_DELETE
+    def delete_guild_role(data)
+      role_data = data['role']
+      role_id = role_data['id'].to_i
+      server_id = data['guild_id'].to_i
+      server = @servers[server_id]
+      server.delete_role(role_id)
+    end
 
     def debug(message)
       puts "[DEBUG @ #{Time.now.to_s}] #{message}" if @debug
@@ -369,6 +416,22 @@ module Discordrb
       when "CHANNEL_DELETE"
         delete_channel(data)
         event = ChannelDeleteEvent.new(data, self)
+        raise_event(event)
+      when "GUILD_MEMBER_UPDATE"
+        update_guild_member(data)
+        event = GuildMemberUpdateEvent.new(data, self)
+        raise_event(event)
+      when "GUILD_ROLE_UPDATE"
+        update_guild_role(data)
+        event = GuildRoleUpdateEvent.new(data, self)
+        raise_event(event)
+      when "GUILD_ROLE_CREATE"
+        create_guild_role(data)
+        event = GuildRoleCreateEvent.new(data, self)
+        raise_event(event)
+      when "GUILD_ROLE_DELETE"
+        delete_guild_role(data)
+        event = GuildRoleDeleteEvent.new(data, self)
         raise_event(event)
       end
       rescue Exception => e

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1,5 +1,7 @@
 # These classes hold relevant Discord data, such as messages or channels.
 
+require 'ostruct'
+
 module Discordrb
   class User
     attr_reader :username, :id, :discriminator, :avatar
@@ -11,16 +13,19 @@ module Discordrb
     attr_accessor :self_mute
     attr_accessor :self_deaf
     attr_reader :voice_channel
+    attr_reader :roles
 
     alias_method :name, :username
 
-    def initialize(data, bot)
+    def initialize(data, bot, server = nil)
       @bot = bot
 
       @username = data['username']
       @id = data['id'].to_i
       @discriminator = data['discriminator']
       @avatar = data['avatar']
+      @server = server
+      @roles = []
       
       @status = :offline
     end
@@ -47,10 +52,85 @@ module Discordrb
       return if to_channel && to_channel.type != 'voice'
       @voice_channel = to_channel
     end
+    
+    # Set this user's roles
+    def update_roles(roles)
+      @roles = roles
+    end
+  end
+  
+  class Role
+    attr_reader :permissions
+    attr_reader :name
+    attr_reader :id
+    attr_reader :hoist
+    attr_reader :color
+    
+    def initialize(data, bot, server = nil)
+      @permissions = Permissions.new(data['permissions'])
+      @name = data['name']
+      @id = data['id'].to_i
+      @hoist = data['hoist']
+      @color = ColorRGB.new(data['color'])
+    end
+    
+    def update_from(other)
+      @permissions = other.permissions
+      @name = other.name
+      @hoist = other.hoist
+      @color = other.color
+    end
+  end
+  
+  class Permissions
+    # This hash maps bit positions to logical permissions.
+    # I'm not sure what the unlabeled bits are reserved for.
+    Flags = {
+      # Bit => Permission # Value
+      0 => :create_instant_invite, # 1
+      1 => :kick_members,          # 2
+      2 => :ban_members,           # 4
+      3 => :manage_roles ,         # 8
+      4 => :manage_channels,       # 16
+      5 => :manage_server,         # 32
+      6 => :read_messages,         # 64
+      #7                           # 128
+      #8                           # 256
+      #9                           # 512
+      #10                          # 1024
+      11 => :send_messages,        # 2048
+      12 => :send_tts_messages,    # 4096
+      13 => :manage_messages,      # 8192
+      14 => :embed_links,          # 16384
+      15 => :attach_files,         # 32768
+      16 => :read_message_history, # 65536
+      17 => :mention_everyone,     # 131072
+      #18                          # 262144
+      #19                          # 524288
+      20 => :connect,              # 1048576
+      21 => :speak,                # 2097152
+      22 => :mute_members,         # 4194304
+      23 => :deafen_members,       # 8388608
+      24 => :move_members,         # 16777216
+      25 => :use_voice_activity    # 33554432
+    }
+             
+    Flags.each_value do |flag|
+      attr_reader flag
+    end
+  
+    def initialize(bits)
+      Flags.each do |position, flag|
+        flag_set = ((bits >> position) & 0x1) == 1
+        instance_variable_set "@#{flag}", flag_set
+      end
+    end
   end
 
   class Channel
     attr_reader :name, :server, :type, :id, :is_private, :recipient, :topic
+    
+    attr_reader :permission_overwrites
 
     def initialize(data, bot, server = nil)
       @bot = bot
@@ -71,6 +151,19 @@ module Discordrb
         @server = bot.server(data['guild_id'].to_i)
         @server = server if !@server
       end
+      
+      # Populate permission overwrites
+      @permission_overwrites = {}
+      if data['permission_overwrites']
+        data['permission_overwrites'].each do |element|
+          role_id = element['id'].to_i
+          deny = Permissions.new(element['deny'])
+          allow = Permissions.new(element['allow'])
+          @permission_overwrites[role_id] = OpenStruct.new
+          @permission_overwrites[role_id].deny = deny
+          @permission_overwrites[role_id].allow = allow
+        end
+      end
     end
 
     def send_message(content)
@@ -82,6 +175,7 @@ module Discordrb
       @name = other.name
       @is_private = other.is_private
       @recipient = other.recipient
+      @permission_overwrites = other.permission_overwrites
     end
     
     # List of users currently in a channel
@@ -95,6 +189,10 @@ module Discordrb
           end
         end
       end
+    end
+    
+    def update_overwrites(overwrites)
+      @permission_overwrites = overwrites
     end
 
     alias_method :send, :send_message
@@ -127,6 +225,9 @@ module Discordrb
 
     # Array of channels on the server
     attr_reader :channels
+    
+    # Array of roles on the server
+    attr_reader :roles
 
     def initialize(data, bot)
       @bot = bot
@@ -135,13 +236,28 @@ module Discordrb
       @owner_id = data['owner_id'].to_i
       @id = data['id'].to_i
       
+      # Create roles
+      @roles = []
+      roles_by_id = {}
+      data['roles'].each do |element|
+        role = Role.new(element, bot)
+        @roles << role
+        roles_by_id[role.id] = role
+      end
+      
       @members = []
       members_by_id = {}
 
       data['members'].each do |element|
-        user = User.new(element['user'], bot)
+        user = User.new(element['user'], bot, self)
         @members << user
         members_by_id[user.id] = user
+        user_roles = []
+        element['roles'].each do |element|
+          role_id = element.to_i
+          user_roles << roles_by_id[role_id]
+        end
+        user.update_roles(user_roles)
       end
 
       # Update user statuses with presence info
@@ -187,6 +303,32 @@ module Discordrb
           end
         end
       end
+    end
+    
+    def add_role(role)
+      @roles << role
+    end
+    
+    def delete_role(role_id)
+      @roles.reject! {|r| r.id == role_id}
+      @members.each do |user|
+        new_roles = user.roles.reject {|r| r.id == role_id}
+        user.update_roles(new_roles)
+      end
+      @channels.each do |channel|
+        overwrites = channel.permission_overwrites.reject {|id, perm| id == role_id}
+        channel.update_overwrites(overwrites)
+      end
+    end
+  end
+  
+  class ColorRGB
+    attr_reader :red, :green, :blue
+    
+    def initialize(combined)
+      @red = (combined >> 16) & 0xFF
+      @green = (combined >> 8) & 0xFF
+      @blue = combined & 0xFF
     end
   end
 end

--- a/lib/discordrb/events/channel-create.rb
+++ b/lib/discordrb/events/channel-create.rb
@@ -25,7 +25,7 @@ module Discordrb::Events
   class ChannelCreateEventHandler < EventHandler
     def matches?(event)
       # Check for the proper event type
-      return false unless event.is_a? VoiceStateUpdateEvent
+      return false unless event.is_a? ChannelCreateEvent
 
       return [
         matches_all(@attributes[:type], event.type) do |a,e|

--- a/lib/discordrb/events/channel-delete.rb
+++ b/lib/discordrb/events/channel-delete.rb
@@ -8,7 +8,7 @@ module Discordrb::Events
     attr_reader :position
     attr_reader :name
     attr_reader :is_private
-    attr_reader :channel
+    attr_reader :id
     attr_reader :server
 
     def initialize(data, bot)
@@ -17,16 +17,15 @@ module Discordrb::Events
       @position = data['position']
       @name = data['name']
       @is_private = data['is_private']
+      @id = data['id'].to_i
       @server = bot.server(data['guild_id'].to_i)
-      return if !@server
-      @channel = bot.channel(data['id'].to_i)
     end
   end
 
   class ChannelDeleteEventHandler < EventHandler
     def matches?(event)
       # Check for the proper event type
-      return false unless event.is_a? VoiceStateUpdateEvent
+      return false unless event.is_a? ChannelDeleteEvent
 
       return [
         matches_all(@attributes[:type], event.type) do |a,e|

--- a/lib/discordrb/events/channel-update.rb
+++ b/lib/discordrb/events/channel-update.rb
@@ -26,7 +26,7 @@ module Discordrb::Events
   class ChannelUpdateEventHandler < EventHandler
     def matches?(event)
       # Check for the proper event type
-      return false unless event.is_a? VoiceStateUpdateEvent
+      return false unless event.is_a? ChannelUpdateEvent
 
       return [
         matches_all(@attributes[:type], event.type) do |a,e|

--- a/lib/discordrb/events/guild-member-update.rb
+++ b/lib/discordrb/events/guild-member-update.rb
@@ -1,0 +1,40 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class GuildMemberUpdateEvent
+    attr_reader :user
+    attr_reader :roles
+    attr_reader :server
+
+    def initialize(data, bot)
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      
+      user_id = data['user']['id'].to_i
+      @user = @server.members.find {|u| u.id == user_id}
+      @roles = []
+      data['roles'].each do |element|
+        role_id = element.to_i
+        @roles << @server.roles.find {|r| r.id == role_id}
+      end
+    end
+  end
+
+  class GuildMemberUpdateHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? GuildMemberUpdateEvent
+
+      return [
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/guild-role-create.rb
+++ b/lib/discordrb/events/guild-role-create.rb
@@ -1,0 +1,34 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class GuildRoleCreateEvent
+    attr_reader :role
+    attr_reader :server
+
+    def initialize(data, bot)
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      
+      role_id = data['role']['id'].to_i
+      @role = @server.roles.find {|r| r.id == role_id}
+    end
+  end
+
+  class GuildRoleCreateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? GuildRoleCreateEvent
+
+      return [
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/guild-role-delete.rb
+++ b/lib/discordrb/events/guild-role-delete.rb
@@ -1,0 +1,35 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class GuildRoleDeleteEvent
+    attr_reader :id
+    attr_reader :server
+
+    def initialize(data, bot)
+      # The role should already be deleted from the server's list
+      # by the time we create this event, so we'll create a temporary
+      # role object for event consumers to use.
+      @id = data['role_id'].to_i
+      server_id = data['guild_id'].to_i
+      @server = bot.server(server_id)
+    end
+  end
+
+  class GuildRoleDeleteEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? GuildRoleDeleteEvent
+
+      return [
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end

--- a/lib/discordrb/events/guild-role-update.rb
+++ b/lib/discordrb/events/guild-role-update.rb
@@ -1,0 +1,34 @@
+require 'discordrb/events/generic'
+require 'discordrb/data'
+
+module Discordrb::Events
+  class GuildRoleUpdateEvent
+    attr_reader :role
+    attr_reader :server
+
+    def initialize(data, bot)
+      @server = bot.server(data['guild_id'].to_i)
+      return if !@server
+      
+      role_id = data['role']['id'].to_i
+      @role = @server.roles.find {|r| r.id == role_id}
+    end
+  end
+
+  class GuildRoleUpdateEventHandler < EventHandler
+    def matches?(event)
+      # Check for the proper event type
+      return false unless event.is_a? GuildRoleUpdateEvent
+
+      return [
+        matches_all(@attributes[:name], event.name) do |a,e|
+          if a.is_a? String
+            a == e.to_s
+          else
+            a == e
+          end
+        end
+      ].reduce(true, &:&)
+    end
+  end
+end


### PR DESCRIPTION
## Roles & Permissions ##

* Added Permissions class, which parses Discord's permissions bits into logical permissions.
* Added the Role class. Servers have roles, users on servers have roles.
* Roles have permissions.
* Channels have permission overwrites. These allow a channel to specify special permissions for certain roles in that channel.
* Added a method to query user permissions.

## Events ##

* Added GUILD_MEMBER_UPDATE and automatically handled changing a user's roles.
* Added GUILD_ROLE_CREATE, GUILD_ROLE_DELETE, and GUILD_ROLE_UPDATE and automatically handled creating, deleting, and modifying roles.

## Bug Fixes ##

* There were some incorrect class references in the event classes that I added in the last pull request. These have been fixed.
* The CHANNEL_DELETE event would crash because it was trying to look up a channel that was no longer present.
* @bot_user in Discordrb::Bot was not the same object as the corresponding user in @users. They now both point to the same object.