### PR TITLE
Fix error resulting from accessing invite object as a hash instead of an object

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -213,7 +213,7 @@ module Discordrb
     # Makes the bot join an invite to a server.
     # @param invite [String, Invite] The invite to join. For possible formats see {#resolve_invite_code}.
     def join(invite)
-      resolved = invite(invite)['code']
+      resolved = invite(invite).code
       API.join_server(token, resolved)
     end
 


### PR DESCRIPTION
This PR addresses an issue I ran into while implementing a bot using this API. ```bot#join``` throws up because the ```#invite``` method returns an object, rather than a hash. It appears this method is assuming a hash (maybe an implementation change at some point?). This is a relatively simple fix that should address that error.