### PR TITLE
Disables rbnacl library if DISCORDRB_NONACL env var is set.

### DIFF
--- a/lib/discordrb/voice/network.rb
+++ b/lib/discordrb/voice/network.rb
@@ -4,12 +4,14 @@ require 'socket'
 require 'json'
 
 begin
-  require 'rbnacl'
-  RBNACL_AVAILABLE = true
+  RBNACL_AVAILABLE = false
+  unless ENV::has_key?('DISCORDRB_NONACL')
+    require 'rbnacl'
+    RBNACL_AVAILABLE = true
+  end
 rescue LoadError
   puts "libsodium not available! You can continue to use discordrb as normal but voice support won't work.
         Read https://github.com/meew0/discordrb/wiki/Installing-libsodium for more details."
-  RBNACL_AVAILABLE = false
 end
 
 module Discordrb::Voice


### PR DESCRIPTION
It does not just mute the message, it completely skips trying to load it.