### PR TITLE
fix #split_message chopping off more than it got

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -42,7 +42,7 @@ module Discordrb
     tri = [*0..(lines.length - 1)].map { |i| lines.combination(i + 1).first }
 
     # Join the individual elements together to get an array of strings with consecutively more lines
-    joined = tri.map { |e| e.join }
+    joined = tri.map(&:join)
 
     # Find the largest element that is still below the character limit, or if none such element exists return the first
     ideal = joined.max_by { |e| e.length > CHARACTER_LIMIT ? -1 : e.length }

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -42,7 +42,7 @@ module Discordrb
     tri = [*0..(lines.length - 1)].map { |i| lines.combination(i + 1).first }
 
     # Join the individual elements together to get an array of strings with consecutively more lines
-    joined = tri.map { |e| e.join("\n") }
+    joined = tri.map { |e| e.join }
 
     # Find the largest element that is still below the character limit, or if none such element exists return the first
     ideal = joined.max_by { |e| e.length > CHARACTER_LIMIT ? -1 : e.length }

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -3,16 +3,16 @@ require 'discordrb'
 describe Discordrb do
   it 'should split messages correctly' do
     split = Discordrb.split_message('a' * 5234)
-    split.should eq(["a" * 2000, "a" * 2000, "a" * 1234])
+    split.should eq(['a' * 2000, 'a' * 2000, 'a' * 1234])
 
     # regression test
     # there had been an issue where this would have raised an error,
     # and (if it hadn't raised) produced incorrect results
-    split = Discordrb.split_message(("a" * 800 + "\n") * 6)
+    split = Discordrb.split_message(('a' * 800 + "\n") * 6)
     split.should eq([
-      "a" * 800 + "\n" + "a" * 800 + "\n",
-      "a" * 800 + "\n" + "a" * 800 + "\n",
-      "a" * 800 + "\n" + "a" * 800
-    ])
+                      'a' * 800 + "\n" + 'a' * 800 + "\n",
+                      'a' * 800 + "\n" + 'a' * 800 + "\n",
+                      'a' * 800 + "\n" + 'a' * 800
+                    ])
   end
 end

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -1,0 +1,18 @@
+require 'discordrb'
+
+describe Discordrb do
+  it 'should split messages correctly' do
+    split = Discordrb.split_message('a' * 5234)
+    split.should eq(["a" * 2000, "a" * 2000, "a" * 1234])
+
+    # regression test
+    # there had been an issue where this would have raised an error,
+    # and (if it hadn't raised) produced incorrect results
+    split = Discordrb.split_message(("a" * 800 + "\n") * 6)
+    split.should eq([
+      "a" * 800 + "\n" + "a" * 800 + "\n",
+      "a" * 800 + "\n" + "a" * 800 + "\n",
+      "a" * 800 + "\n" + "a" * 800
+    ])
+  end
+end


### PR DESCRIPTION
When at the last element in the recursion, `ideal` became bigger than `msg`, since it contains all the newlines from the `join` operation.

This would cause 1) `msg[ideal.length..-1]` to become `nil`, causing future operations like `strip` to fail (and people probably not expecting `nil` in the returned value), and 2) `rest` containing superfluous / doubled newlines, causing some characters at the beginning of `rest` to be missing.

This is probably due to expecting `String#lines` to return lines with stripped newlines. Which for whatever reason is [not the case for Ruby](http://ruby-doc.org/core-2.3.0/String.html#method-i-each_line).

From my own limited test, this has fixed the issues I had experienced. I also added a test where reverting the change would reproduce the error.