### PR TITLE
Add the ability to retrieve channels to light_bot

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -288,6 +288,16 @@ module Discordrb::API
     )
   end
 
+  # List Channels for a Server
+  def list_channels(token, server_id)
+    request(
+      nil,
+      :get,
+      "#{api_base}/guides/#{server_id}/channels",
+      Authorization: token
+    )
+  end
+
   # Create a channel
   def create_channel(token, server_id, name, type)
     request(

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -293,7 +293,7 @@ module Discordrb::API
     request(
       nil,
       :get,
-      "#{api_base}/guides/#{server_id}/channels",
+      "#{api_base}/guilds/#{server_id}/channels",
       Authorization: token
     )
   end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -697,26 +697,40 @@ module Discordrb
     end
   end
 
-  # A Discord channel, including data like the topic
-  class Channel
-    # The type string that stands for a text channel
-    # @see Channel#type
-    TEXT_TYPE = 'text'.freeze
-
-    # The type string that stands for a voice channel
-    # @see Channel#type
-    VOICE_TYPE = 'voice'.freeze
-
-    include IDObject
-
+  # The most basic attributes a channel should have
+  module ChannelAttributes
     # @return [String] this channel's name.
     attr_reader :name
 
-    # @return [Server, nil] the server this channel is on. If this channel is a PM channel, it will be nil.
-    attr_reader :server
-
     # @return [String] the type of this channel (currently either 'text' or 'voice')
     attr_reader :type
+
+    # The type string that stands for a text channel
+    # @see ChannelAttributes#type
+    TEXT_TYPE = 'text'.freeze
+
+    # The type string that stands for a voice channel
+    # @see ChannelAttributes#type
+    VOICE_TYPE = 'voice'.freeze
+
+    # @return [true, false] whether or not this channel is a text channel
+    def text?
+      @type == TEXT_TYPE
+    end
+
+    # @return [true, false] whether or not this channel is a voice channel
+    def voice?
+      @type == VOICE_TYPE
+    end
+  end
+
+  # A Discord channel, including data like the topic
+  class Channel
+    include IDObject
+    include ChannelAttributes
+
+    # @return [Server, nil] the server this channel is on. If this channel is a PM channel, it will be nil.
+    attr_reader :server
 
     # @return [Recipient, nil] the recipient of the private messages, or nil if this is not a PM channel
     attr_reader :recipient
@@ -779,16 +793,6 @@ module Discordrb
         @permission_overwrites[role_id].deny = deny
         @permission_overwrites[role_id].allow = allow
       end
-    end
-
-    # @return [true, false] whether or not this channel is a text channel
-    def text?
-      @type == TEXT_TYPE
-    end
-
-    # @return [true, false] whether or not this channel is a voice channel
-    def voice?
-      @type == VOICE_TYPE
     end
 
     # Sends a message to this channel.

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -706,11 +706,11 @@ module Discordrb
     attr_reader :type
 
     # The type string that stands for a text channel
-    # @see ChannelAttributes#type
+    # @see Channel#type
     TEXT_TYPE = 'text'.freeze
 
     # The type string that stands for a voice channel
-    # @see ChannelAttributes#type
+    # @see Channel#type
     VOICE_TYPE = 'voice'.freeze
 
     # @return [true, false] whether or not this channel is a text channel

--- a/lib/discordrb/light/data.rb
+++ b/lib/discordrb/light/data.rb
@@ -62,12 +62,22 @@ module Discordrb::Light
 
   # Represents a light channel which only has a fraction of the properties of any other server.
   class LightChannel
+    attr_reader :id
     attr_reader :name
     attr_reader :server
     attr_reader :type
 
+    # @return [Discordrb::Permissions] the permissions that LightBot has in this channel (may be overridden from the server permissions)
+    attr_reader :bot_permissions
+
     def initialize(data, bot)
-      super(data, bot)
+      @bot = bot
+
+      @id = data['id'].to_i
+      @server_id = data['server_id'].to_i
+
+      @name = data['name']
+      @type = data['type']
 
       @bot_permissions = Discordrb::Permissions.new(data['permissions'])
     end

--- a/lib/discordrb/light/data.rb
+++ b/lib/discordrb/light/data.rb
@@ -64,22 +64,22 @@ module Discordrb::Light
   class LightChannel
     attr_reader :id
     attr_reader :name
-    attr_reader :server
+    attr_reader :server_id
     attr_reader :type
 
     # @return [Discordrb::Permissions] the permissions that LightBot has in this channel (may be overridden from the server permissions)
-    attr_reader :bot_permissions
+    #attr_reader :bot_permissions
 
     def initialize(data, bot)
       @bot = bot
 
       @id = data['id'].to_i
-      @server_id = data['server_id'].to_i
+      @server_id = data['guild_id'].to_i
 
       @name = data['name']
       @type = data['type']
 
-      @bot_permissions = Discordrb::Permissions.new(data['permissions'])
+      #@bot_permissions = Discordrb::Permissions.new(data['permissions'])
     end
   end
 end

--- a/lib/discordrb/light/data.rb
+++ b/lib/discordrb/light/data.rb
@@ -60,15 +60,10 @@ module Discordrb::Light
     end
   end
 
-  # Represents a light channel which only has a fraction of the properties of any other server.
-  class LightChannel
-    attr_reader :id
-    attr_reader :name
-    attr_reader :server_id
-    attr_reader :type
-
-    # @return [Discordrb::Permissions] the permissions that LightBot has in this channel (may be overridden from the server permissions)
-    #attr_reader :bot_permissions
+  # A channel that only as  name, type, parent server ID, and channel ID associated with it.
+  class UltraLightChannel
+    include Discordrb::IDObject
+    include Discordrb::ChannelAttributes
 
     def initialize(data, bot)
       @bot = bot
@@ -78,8 +73,25 @@ module Discordrb::Light
 
       @name = data['name']
       @type = data['type']
+    end
+  end
 
-      #@bot_permissions = Discordrb::Permissions.new(data['permissions'])
+  # Represents a light channel which only has a fraction of the properties of any other channel.
+  class LightChannel < UltraLightChannel
+    # @return [Discordrb::Permissions] the specific overrides for the user in this channel
+    attr_reader :permission_overwrites
+
+    # @return [true, false] whether or not this channel is the server's default (usually "#general") channel.
+    def default_channel
+      @id == @server_id
+    end
+    alias_method :default_channel?, :default_channel
+
+    # @!visibility private
+    def initialize(data, bot)
+      super(data, bot)
+
+      @bot_permissions = Discordrb::Permissions.new(data['permission_overwrites'])
     end
   end
 end

--- a/lib/discordrb/light/data.rb
+++ b/lib/discordrb/light/data.rb
@@ -59,4 +59,17 @@ module Discordrb::Light
       @bot_permissions = Discordrb::Permissions.new(data['permissions'])
     end
   end
+
+  # Represents a light channel which only has a fraction of the properties of any other server.
+  class LightChannel
+    attr_reader :name
+    attr_reader :server
+    attr_reader :type
+
+    def initialize(data, bot)
+      super(data, bot)
+
+      @bot_permissions = Discordrb::Permissions.new(data['permissions'])
+    end
+  end
 end

--- a/lib/discordrb/light/data.rb
+++ b/lib/discordrb/light/data.rb
@@ -48,8 +48,13 @@ module Discordrb::Light
     attr_reader :bot_is_owner
     alias_method :bot_is_owner?, :bot_is_owner
 
-    # @return [Discordrb::Permissions] the permissions the LightBot has on this server
+    # @return [Discordrb::Permissions] the permissions the LightBot has on this server.
     attr_reader :bot_permissions
+
+    # @return [Array<LightChannel>] the channels within the specified server.
+    def channels
+      @bot.channels(self.id)
+    end
 
     # @!visibility private
     def initialize(data, bot)
@@ -90,8 +95,6 @@ module Discordrb::Light
     # @!visibility private
     def initialize(data, bot)
       super(data, bot)
-
-      @bot_permissions = Discordrb::Permissions.new(data['permission_overwrites'])
     end
   end
 end

--- a/lib/discordrb/light/light_bot.rb
+++ b/lib/discordrb/light/light_bot.rb
@@ -39,6 +39,11 @@ module Discordrb::Light
       JSON.parse(response).map { |e| LightServer.new(e, self) }
     end
 
+    def channels
+      response = Discordrb::API.list_channels(@token, server_id)
+      JSON.parse(response).map { |e| LightChannel.new(e, self) }
+    end
+
     # Joins a server using an instant invite.
     # @param code [String] The code part of the invite (for example 0cDvIgU2voWn4BaD if the invite URL is
     #   https://discord.gg/0cDvIgU2voWn4BaD)

--- a/lib/discordrb/light/light_bot.rb
+++ b/lib/discordrb/light/light_bot.rb
@@ -39,7 +39,9 @@ module Discordrb::Light
       JSON.parse(response).map { |e| LightServer.new(e, self) }
     end
 
-    def channels
+    # @param server_id [Integer] The numeric ID of the server to retrieve channels for.
+    # @return [Array<LightChannels>] the channels within the specified server.
+    def channels(server_id)
       response = Discordrb::API.list_channels(@token, server_id)
       JSON.parse(response).map { |e| LightChannel.new(e, self) }
     end


### PR DESCRIPTION
These changes add a new API call to explicitly list channels for a given server_id, in addition to setting up the LightChannel structure to retrieve only the most critical channel attributes.

:warning: :fire: :skull: **not ready to be merged yet** :skull: :fire: :warning:

Hit List of changes still needing to be made:
- [ ] Bot Permissions need to be included at the channel level due to per-channel overrides
- [x] Documentation (:green_heart: RubyDoc)
- [x] Is a channel's topic critical? I think not, but feedback welcome.
- [x] Need the :white_check_mark: from Travis CI