### PR TITLE
Fixed the examples

### DIFF
--- a/examples/eval.rb
+++ b/examples/eval.rb
@@ -2,13 +2,13 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new 'email@example.com', 'hunter2'
+bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
 
-bot.command(:eval, help_available: false) do |event, code|
-  break if event.user.id == 000000 # Replace number with your ID
+bot.command(:eval, help_available: false) do |event, *code|
+  break unless event.user.id == 000000 # Replace number with your ID
 
   begin
-    eval(code)
+    eval code.join(' ')
   rescue
     "An error occured 😞"
   end

--- a/examples/eval.rb
+++ b/examples/eval.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', application_id: 160123456789876543, prefix: '!'
 
 bot.command(:eval, help_available: false) do |event, *code|
   break unless event.user.id == 000000 # Replace number with your ID

--- a/examples/ping_with_respond_time.rb
+++ b/examples/ping_with_respond_time.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', application_id: 160123456789876543, prefix: '!'
 
 bot.command(:ping) do |event|
   m = event.respond('Pong!')

--- a/examples/ping_with_respond_time.rb
+++ b/examples/ping_with_respond_time.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new 'email@example.com', 'hunter2'
+bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
 
 bot.command(:ping) do |event|
   m = event.respond('Pong!')

--- a/examples/shutdown.rb
+++ b/examples/shutdown.rb
@@ -2,10 +2,10 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new 'email@example.com', 'hunter2'
+bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
 
 bot.command(:exit, help_available: false) do |event|
-  break if event.user.id == 000000 # Replace number with your ID
+  break unless event.user.id == 000000 # Replace number with your ID
 
   bot.send_message(event.channel.id, 'Bot is shutting down')
   exit

--- a/examples/shutdown.rb
+++ b/examples/shutdown.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new email: 'email@example.com', password: 'hunter2', prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', application_id: 160123456789876543, prefix: '!'
 
 bot.command(:exit, help_available: false) do |event|
   break unless event.user.id == 000000 # Replace number with your ID


### PR DESCRIPTION
Updated the examples

- bot initializers now use named parameters
  - a `prefix` needs to be specified
- the logic in some examples was set to break `if`the user id was present rather than `unless`
- the `eval` example would not allowed spaces unless `advanced_functionality` was enabled (disabled by default since 2.0.0)