### PR TITLE
Heartbeat event

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1343,6 +1343,9 @@ module Discordrb
 
     def send_heartbeat(sequence = nil)
       sequence ||= @sequence
+
+      raise_event(HeartbeatEvent.new(self))
+
       LOGGER.out("Sending heartbeat with sequence #{sequence}")
       data = {
         op: Opcodes::HEARTBEAT,

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -56,6 +56,21 @@ module Discordrb
       register_event(DisconnectEvent, attributes, block)
     end
 
+    # This **event** is raised every time the bot sends a heartbeat over the galaxy. This happens roughly every 40
+    # seconds, but may happen at a lower rate should Discord change their interval. It may also happen more quickly for
+    # periods of time, especially for unstable connections, since discordrb rather sends a heartbeat than not if there's
+    # a choice. (You shouldn't rely on all this to be accurately timed.)
+    #
+    # All this makes this event useful to periodically trigger something, like doing some API request every hour,
+    # setting some kind of uptime variable or whatever else. The only limit is yourself.
+    # @param attributes [Hash] Event attributes, none in this particular case
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [HeartbeatEvent] The event that was raised.
+    # @return [HeartbeatEventHandler] The event handler that was registered.
+    def heartbeat(attributes = {}, &block)
+      register_event(HeartbeatEvent, attributes, block)
+    end
+
     # This **event** is raised when somebody starts typing in a channel the bot is also in. The official Discord
     # client would display the typing indicator for five seconds after receiving this event. If the user continues
     # typing after five seconds, the event will be re-raised.

--- a/lib/discordrb/events/lifetime.rb
+++ b/lib/discordrb/events/lifetime.rb
@@ -22,4 +22,10 @@ module Discordrb::Events
 
   # Event handler for {DisconnectEvent}
   class DisconnectEventHandler < TrueEventHandler; end
+
+  # @see Discordrb::EventContainer#heartbeat
+  class HeartbeatEvent < LifetimeEvent; end
+
+  # Event handler for {HeartbeatEvent}
+  class HeartbeatEventHandler < TrueEventHandler; end
 end


### PR DESCRIPTION
An event that gets triggered every time a heartbeat is sent, useful for periodic updates of whatever kind.

*This PR exists to track the status of this feature for the next release.*