### PR TITLE
Required permissions for commands

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -150,7 +150,8 @@ module Discordrb::Commands
         event.respond @attributes[:command_doesnt_exist_message].gsub('%command%', name.to_s) if @attributes[:command_doesnt_exist_message]
         return
       end
-      if permission?(event.user, command.attributes[:permission_level], event.server)
+      if permission?(event.user, command.attributes[:permission_level], event.server) &&
+         required_permissions?(event.author, command.attributes[:required_permissions], event.channel)
         event.command = command
         result = command.call(event, arguments, chained)
         stringify(result)

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -222,6 +222,12 @@ module Discordrb::Commands
       execute_chain(chain, event)
     end
 
+    def required_permissions?(member, required, channel = nil)
+      required.reduce(true) do |a, action|
+        a && member.permission?(action, channel)
+      end
+    end
+
     def execute_chain(chain, event)
       t = Thread.new do
         @event_threads << t

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -20,6 +20,8 @@ module Discordrb::Commands
     # @option attributes [String, false] :permission_message Message to display when a user does not have sufficient
     #   permissions to execute a command. %name% in the message will be replaced with the name of the command. Disable
     #   the message by setting this option to false.
+    # @option attributes [Array<Symbol>] :required_permissions Discord action permissions (e.g. `:kick_members`) that
+    #   should be required to use this command. See {Discordrb::Permissions::Flags} for a list.
     # @option attributes [true, false] :chain_usable Whether this command is able to be used inside of a command chain
     #   or sub-chain. Typically used for administrative commands that shouldn't be done carelessly.
     # @option attributes [true, false] :help_available Whether this command is visible in the help command. See the

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -19,6 +19,9 @@ module Discordrb::Commands
         # Message to display when a user does not have sufficient permissions to execute a command
         permission_message: (attributes[:permission_message].is_a? FalseClass) ? nil : (attributes[:permission_message] || "You don't have permission to execute command %name%!"),
 
+        # Discord action permissions required to use this command
+        required_permissions: attributes[:required_permissions] || [],
+
         # Whether this command is usable in a command chain
         chain_usable: attributes[:chain_usable].nil? ? true : attributes[:chain_usable],
 


### PR DESCRIPTION
An attribute `:required_permissions` for commands that is an array of actions the user needs to be able to use this command (for example `:kick_members` or `:mention_everyone`)