### PR TITLE
Updated the #prune Channel method to make use of bulk_delete

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -415,6 +415,18 @@ module Discordrb::API
     )
   end
 
+  # Delete messages in bulk
+  def bulk_delete(token, channel_id, messages = [])
+    request(
+      __method__,
+      :post,
+      "#{api_base}/channels/#{channel_id}/messages/bulk_delete",
+      { messages: messages }.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Edit a message
   def edit_message(token, channel_id, message_id, message, mentions = [])
     request(

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1005,26 +1005,17 @@ module Discordrb
       JSON.parse(logs).map { |message| Message.new(message, @bot) }
     end
 
-    # Deletes the last N messages on this channel. Each delete request is performed in a separate thread for performance
-    # reasons, so if a large number of messages are pruned, many threads will be created.
-    # @note As of the April 29 update, the message delete request is rate limited, which means this method will take
-    #   a long time. It will eventually be updated to use batch deletes once those are released, but that will be in the
-    #   far future.
-    # @param amount [Integer] How many messages to delete. Must be 100 or less (Discord limitation)
+    # Delete the last N messages on this channel.
+    # @param amount [Integer] How many messages to delete. Must be a value between 1 and 100 (Discord limitation)
     # @raise [ArgumentError] if more than 100 messages are requested.
+    # @raise [ArgumentError] if 0 messages are requested.
     def prune(amount)
       raise ArgumentError, "Can't prune more than 100 messages!" if amount > 100
+      raise ArgumentError, "Can't prune 0 messages!" if amount.zero?
 
-      threads = []
-      history(amount).each do |message|
-        threads << Thread.new { message.delete }
-      end
-
-      # Make sure all requests have finished
-      threads.each(&:join)
-
-      # Delete the threads
-      threads.map! { nil }
+      messages = history(amount).map(&:id)
+      API.bulk_delete(@bot.token, @id, messages)
+      nil
     end
 
     # Updates the cached permission overwrites

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1006,16 +1006,13 @@ module Discordrb
     end
 
     # Delete the last N messages on this channel.
-    # @param amount [Integer] How many messages to delete. Must be a value between 1 and 100 (Discord limitation)
-    # @raise [ArgumentError] if more than 100 messages are requested.
-    # @raise [ArgumentError] if 0 messages are requested.
+    # @param amount [Integer] How many messages to delete. Must be a value between 2 and 100 (Discord limitation)
+    # @raise [ArgumentError] if the amount of messages is not a value between 2 and 100
     def prune(amount)
-      raise ArgumentError, "Can't prune more than 100 messages!" if amount > 100
-      raise ArgumentError, "Can't prune 0 messages!" if amount.zero?
+      raise ArgumentError, 'Can only prune between 2 and 100 messages!' unless amount.between?(2, 100)
 
       messages = history(amount).map(&:id)
       API.bulk_delete(@bot.token, @id, messages)
-      nil
     end
 
     # Updates the cached permission overwrites


### PR DESCRIPTION
Updated to make use of bulk_delete

https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/resources/CHANNEL.md#bulk-delete-messages--post-channelschanneliddocs_channelchannel-objectsmessagesbulk_delete