### PR TITLE
Playing Event Streaming Support

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -123,6 +123,7 @@ module Discordrb
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer, User] :from Matches the user whose playing game changes.
     # @option attributes [String] :game Matches the game the user is now playing.
+    # @option attributes [Integer] :type Matches the type of game object (0 game, 1 Twitch stream)
     # @yield The block is executed when the event is raised.
     # @yieldparam event [PlayingEvent] The event that was raised.
     # @return [PlayingEventHandler] The event handler that was registered.

--- a/lib/discordrb/events/presence.rb
+++ b/lib/discordrb/events/presence.rb
@@ -62,12 +62,20 @@ module Discordrb::Events
     # @return [String] the new game the user is playing.
     attr_reader :game
 
+    # @return [String] the URL to the stream
+    attr_reader :url
+
+    # @return [Integer] the type of play. 0 = game, 1 = Twitch
+    attr_reader :type
+
     def initialize(data, bot)
       @bot = bot
 
       @user = bot.user(data['user']['id'].to_i)
       @game = data['game'] ? data['game']['name'] : nil
       @server = bot.server(data['guild_id'].to_i)
+      @url = data['game'] ? data['game']['url'] : nil
+      @type = data['game'] ? data['game']['type'].to_i : nil
     end
   end
 
@@ -90,6 +98,13 @@ module Discordrb::Events
         matches_all(@attributes[:game], event.game) do |a, e|
           a == if a.is_a? String
                  e.name
+               else
+                 e
+               end
+        end,
+        matches_all(@attributes[:type], event.type) do |a, e|
+          a == if a.is_a? Integer
+                 e.type
                else
                  e
                end


### PR DESCRIPTION
Adds support for (the not yet documented) `type` and `url` in the presence payload. This indicates if a member is streaming (`type` indicating which service: 0 no stream, 1 twitch; and a `url` provided to the location of the stream).