### PR TITLE
Add API and Channel class support for returning single message by ID

### DIFF
--- a/examples/await.rb
+++ b/examples/await.rb
@@ -1,0 +1,1 @@
+require 'discordrb'

--- a/examples/await.rb
+++ b/examples/await.rb
@@ -1,1 +1,0 @@
-require 'discordrb'

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -687,6 +687,16 @@ module Discordrb::API
     )
   end
 
+  # Get a single message from a channel's history by id
+  def channel_message(token, channel_id, message_id)
+    request(
+      __method__,
+      :get,
+      "#{api_base}/channels/#{channel_id}/messages/#{message_id}",
+      Authorization: token
+    )
+  end
+
   # Get a list of pinned messages in a channel
   def pins(token, channel_id)
     request(

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1093,8 +1093,10 @@ module Discordrb
     # @param message_id [Integer] The ID of the message to retrieve.
     # @return [Message] the retrieved message.
     def load_message(message_id)
-      msg = JSON.parse(API.channel_message(@bot.token, @id, message_id))
-      Message.new(msg, @bot)
+      response = API.channel_message(@bot.token, @id, message_id)
+      return Message.new(JSON.parse(response), @bot)
+    rescue RestClient::ResourceNotFound
+      return nil
     end
 
     # Requests all pinned messages of a channel.

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1089,6 +1089,14 @@ module Discordrb
       JSON.parse(logs).map { |message| Message.new(message, @bot) }
     end
 
+    # Returns a single message from this channel's history by ID.
+    # @param message_id [Integer] The ID of the message to retrieve.
+    # @return [Message] the retrieved message.
+    def get_message(message_id)
+      msg = JSON.parse(API.channel_message(@bot.token, @id, message_id))
+      Message.new(msg, @bot)
+    end
+
     # Requests all pinned messages of a channel.
     # @return [Array<Message>] the received messages.
     def pins

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1092,7 +1092,7 @@ module Discordrb
     # Returns a single message from this channel's history by ID.
     # @param message_id [Integer] The ID of the message to retrieve.
     # @return [Message] the retrieved message.
-    def get_message(message_id)
+    def load_message(message_id)
       msg = JSON.parse(API.channel_message(@bot.token, @id, message_id))
       Message.new(msg, @bot)
     end


### PR DESCRIPTION
With help from @snapcase :smile: 

We took a look at it, and `#message(id)` isn't syntactically possible without removing the `alias :message, :send_message`, or doing a typecheck inside of `send_message`. I wasn't sure if that would be acceptable, so I'd like to know what you think.