### PR TITLE
Correct permissions bitmask

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -247,7 +247,7 @@ module Discordrb
       # (Coincidentally, Manage Permissions is the same permission as Manage Roles, and a
       # Manage Permissions deny overwrite will override Manage Roles, so we can just check for
       # Manage Roles once and call it a day.)
-      return true if defined_permission?(:manage_roles, channel)
+      return true if defined_permission?(:administrate, channel)
 
       # Otherwise, defer to defined_permission
       defined_permission?(action, channel)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -247,7 +247,7 @@ module Discordrb
       # (Coincidentally, Manage Permissions is the same permission as Manage Roles, and a
       # Manage Permissions deny overwrite will override Manage Roles, so we can just check for
       # Manage Roles once and call it a day.)
-      return true if defined_permission?(:administrate, channel)
+      return true if defined_permission?(:administrator, channel)
 
       # Otherwise, defer to defined_permission
       defined_permission?(action, channel)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -278,6 +278,8 @@ module Discordrb
       end
     end
 
+    alias_method :can_administrate?, :can_administrator?
+
     private
 
     def defined_role_permission?(action, channel)

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -10,7 +10,7 @@ module Discordrb
       0 => :create_instant_invite, # 1
       1 => :kick_members,          # 2
       2 => :ban_members,           # 4
-      3 => :administrate,          # 8
+      3 => :administrator,         # 8
       4 => :manage_channels,       # 16
       5 => :manage_server,         # 32
       # 6                          # 64
@@ -52,6 +52,8 @@ module Discordrb
         init_vars
       end
     end
+
+    alias_method :can_administrate=, :can_administrator=
 
     attr_reader :bits
 

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -10,7 +10,7 @@ module Discordrb
       0 => :create_instant_invite, # 1
       1 => :kick_members,          # 2
       2 => :ban_members,           # 4
-      3 => :manage_roles,          # 8, also Manage Permissions
+      3 => :administrate,          # 8
       4 => :manage_channels,       # 16
       5 => :manage_server,         # 32
       # 6                          # 64
@@ -25,7 +25,7 @@ module Discordrb
       15 => :attach_files,         # 32768
       16 => :read_message_history, # 65536
       17 => :mention_everyone,     # 131072
-      # 18                         # 262144
+      18 => :use_external_emoji,   # 262144
       # 19                         # 524288
       20 => :connect,              # 1048576
       21 => :speak,                # 2097152
@@ -34,7 +34,8 @@ module Discordrb
       24 => :move_members,         # 16777216
       25 => :use_voice_activity,   # 33554432
       26 => :change_nickname,      # 67108864
-      27 => :manage_nicknames      # 134217728
+      27 => :manage_nicknames,     # 134217728
+      28 => :manage_roles          # 268435456, also Manage Permissions
     }.freeze
 
     Flags.each do |position, flag|


### PR DESCRIPTION
This sets correct bitmask values and ordering. It also adds the external emoji permission to the hash, enabling `can_use_external_emoji`.

Values were taken from Discord's official API page. For the External Emoji permission value, I created a role which had only that permission, then returned its bitmask. All values were verified myself.