### PR TITLE
add alias_method User#dm for User#pm

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -168,6 +168,8 @@ module Discordrb
       end
     end
 
+    alias_method :dm, :pm
+
     # Send the user a file.
     # @param file [File] The file to send to the user
     # @param caption [String] The caption of the file being sent


### PR DESCRIPTION
Technically PMs are called DMs on discord
I've been trying to use User#dm in the past since I've gotten used to the PMs being called DMs