### PR TITLE
Add support for server's channel endpoint

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -190,6 +190,15 @@ module Discordrb::API
     )
   end
 
+  def channel_invites(token, channel_id)
+    request(
+      __method__,
+      :get,
+      "#{api_base}/channels/#{channel_id}/invites",
+      Authorization: token
+    )
+  end
+
   # Login to the server
   def login(email, password)
     request(

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -180,6 +180,16 @@ module Discordrb::API
     )
   end
 
+  # Get a server's channels list
+  def channels(token, server_id)
+    request(
+      __method__,
+      :get,
+      "#{api_base}/guilds/#{server_id}/channels",
+      Authorization: token
+    )
+  end
+
   # Login to the server
   def login(email, password)
     request(

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -190,6 +190,7 @@ module Discordrb::API
     )
   end
 
+  # Get a channel's invite list
   def channel_invites(token, channel_id)
     request(
       __method__,


### PR DESCRIPTION
This change adds support for the channels endpoint for a server. The authorization token and server_id need to be supplied for this method.