### PR TITLE
Added a parameters option for command def

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -127,6 +127,8 @@ module Discordrb::Commands
           usage = command.attributes[:usage]
           result = "**`#{command_name}`**: #{desc}"
           result += "\nUsage: `#{usage}`" if usage
+          result += "\nAccepted Parameters:" if parameters
+          parameters.each { |p| result += "\n    `#{p}`"} if parameters
           result
         else
           available_commands = @commands.values.reject { |c| !c.attributes[:help_available] }

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -125,6 +125,7 @@ module Discordrb::Commands
           return "The command `#{command_name}` does not exist!" unless command
           desc = command.attributes[:description] || '*No description available*'
           usage = command.attributes[:usage]
+          parameters = command.attributes[:parameters]
           result = "**`#{command_name}`**: #{desc}"
           result += "\nUsage: `#{usage}`" if usage
           result += "\nAccepted Parameters:" if parameters

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -128,8 +128,10 @@ module Discordrb::Commands
           parameters = command.attributes[:parameters]
           result = "**`#{command_name}`**: #{desc}"
           result += "\nUsage: `#{usage}`" if usage
-          result += "\nAccepted Parameters:" if parameters
-          parameters.each { |p| result += "\n    `#{p}`"} if parameters
+          if parameters
+            result += "\nAccepted Parameters:"
+            parameters.each { |p| result += "\n    `#{p}`"}
+          end
           result
         else
           available_commands = @commands.values.reject { |c| !c.attributes[:help_available] }

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -130,7 +130,7 @@ module Discordrb::Commands
           result += "\nUsage: `#{usage}`" if usage
           if parameters
             result += "\nAccepted Parameters:"
-            parameters.each { |p| result += "\n    `#{p}`"}
+            parameters.each { |p| result += "\n    `#{p}`" }
           end
           result
         else

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -36,7 +36,7 @@ module Discordrb::Commands
 
         # Usage description (for help command and error messages)
         usage: attributes[:usage] || nil,
-        
+
         # Parameter list (for help command and error messages)
         parameters: attributes[:parameters] || nil,
 

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -36,6 +36,9 @@ module Discordrb::Commands
 
         # Usage description (for help command and error messages)
         usage: attributes[:usage] || nil,
+        
+        # Parameter list (for help command and error messages)
+        parameters: attributes[:parameters] || nil,
 
         # Minimum number of arguments
         min_args: attributes[:min_args] || 0,


### PR DESCRIPTION
I added a parameters option for the command def, so that the built in !help command can have a little more detail.

You would assign an array to your parameters attribute like so `parameters: ["Thing1, Thing2"]` and then when the !help command is run it will display the parameters if they exist like so:

Parameters:
        `Thing 1`
        `Thing 2`

This would be helpful for commands that accept multiple different parameters.