### PR TITLE
Reintroduce Bot#stop

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -197,6 +197,12 @@ module Discordrb
       @gateway.sync
     end
 
+    # Stops the bot gracefully, disconnecting the websocket without immediately killing the thread. This means that
+    # Discord is immediately aware of the closed connection and makes the bot appear offline instantly.
+    def stop
+      @gateway.stop
+    end
+
     # @return [true, false] whether or not the bot is currently connected to Discord.
     def connected?
       @gateway.open?

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -199,8 +199,9 @@ module Discordrb
 
     # Stops the bot gracefully, disconnecting the websocket without immediately killing the thread. This means that
     # Discord is immediately aware of the closed connection and makes the bot appear offline instantly.
-    def stop
-      @gateway.stop
+    # @param no_sync [true, false] Whether or not to disable use of synchronize in the close method. This should be true if called from a trap context.
+    def stop(no_sync = false)
+      @gateway.stop(no_sync)
     end
 
     # @return [true, false] whether or not the bot is currently connected to Discord.

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -696,7 +696,11 @@ module Discordrb
       # This needs to be synchronised with the getc mutex, so the notification, and especially the actual
       # close afterwards, don't coincide with the main loop reading something from the SSL socket.
       # This would cause a segfault due to (I suspect) Ruby bug #12292: https://bugs.ruby-lang.org/issues/12292
-      @getc_mutex.synchronize { @closed = true } unless no_sync
+      if no_sync
+        @closed = true
+      else
+        @getc_mutex.synchronize { @closed = true }
+      end
 
       # Close the socket if possible
       @socket.close if @socket

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -162,12 +162,12 @@ module Discordrb
     end
 
     # Stops the bot gracefully, disconnecting the websocket without immediately killing the thread. This means that
-    # Discord is immediately aware of the closed connetion and makes the bot appear offline instantly.
+    # Discord is immediately aware of the closed connection and makes the bot appear offline instantly.
     #
     # If this method doesn't work or you're looking for something more drastic, use {#kill} instead.
     def stop
       @should_reconnect = false
-      @ws.close
+      close
     end
 
     # Kills the websocket thread, stopping all connections to Discord.
@@ -369,8 +369,8 @@ module Discordrb
       # Initialize falloff so we wait for more time before reconnecting each time
       @falloff = 1.0
 
+      @should_reconnect = true
       loop do
-        @should_reconnect = true
         connect
 
         break unless @should_reconnect
@@ -638,17 +638,19 @@ module Discordrb
     end
 
     def handle_close(e)
-      if e.respond_to? :code
-        # It is a proper close frame we're dealing with, print reason and message to console
-        LOGGER.error('Websocket close frame received!')
-        LOGGER.error("Code: #{e.code}")
-        LOGGER.error("Message: #{e.data}")
-      elsif e.is_a? Exception
-        # Log the exception
-        LOGGER.error('The websocket connection has closed due to an error!')
-        LOGGER.log_exception(e)
-      else
-        LOGGER.error("The websocket connection has closed due to an unspecified error: #{e.inspect}")
+      unless e.nil?
+        if e.respond_to? :code
+          # It is a proper close frame we're dealing with, print reason and message to console
+          LOGGER.error('Websocket close frame received!')
+          LOGGER.error("Code: #{e.code}")
+          LOGGER.error("Message: #{e.data}")
+        elsif e.is_a? Exception
+          # Log the exception
+          LOGGER.error('The websocket connection has closed due to an error!')
+          LOGGER.log_exception(e)
+        else
+          LOGGER.error("The websocket connection has closed due to an unspecified error: #{e.inspect}")
+        end
       end
     end
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -165,9 +165,9 @@ module Discordrb
     # Discord is immediately aware of the closed connection and makes the bot appear offline instantly.
     #
     # If this method doesn't work or you're looking for something more drastic, use {#kill} instead.
-    def stop
+    def stop(no_sync = false)
       @should_reconnect = false
-      close
+      close(no_sync)
     end
 
     # Kills the websocket thread, stopping all connections to Discord.
@@ -638,19 +638,17 @@ module Discordrb
     end
 
     def handle_close(e)
-      unless e.nil?
-        if e.respond_to? :code
-          # It is a proper close frame we're dealing with, print reason and message to console
-          LOGGER.error('Websocket close frame received!')
-          LOGGER.error("Code: #{e.code}")
-          LOGGER.error("Message: #{e.data}")
-        elsif e.is_a? Exception
-          # Log the exception
-          LOGGER.error('The websocket connection has closed due to an error!')
-          LOGGER.log_exception(e)
-        else
-          LOGGER.error("The websocket connection has closed due to an unspecified error: #{e.inspect}")
-        end
+      if e.respond_to? :code
+        # It is a proper close frame we're dealing with, print reason and message to console
+        LOGGER.error('Websocket close frame received!')
+        LOGGER.error("Code: #{e.code}")
+        LOGGER.error("Message: #{e.data}")
+      elsif e.is_a? Exception
+        # Log the exception
+        LOGGER.error('The websocket connection has closed due to an error!')
+        LOGGER.log_exception(e)
+      else
+        LOGGER.error("The websocket connection has closed: #{e.inspect}")
       end
     end
 
@@ -684,7 +682,7 @@ module Discordrb
       end
     end
 
-    def close
+    def close(no_sync = false)
       # If we're already closed, there's no need to do anything - return
       return if @closed
 
@@ -698,7 +696,7 @@ module Discordrb
       # This needs to be synchronised with the getc mutex, so the notification, and especially the actual
       # close afterwards, don't coincide with the main loop reading something from the SSL socket.
       # This would cause a segfault due to (I suspect) Ruby bug #12292: https://bugs.ruby-lang.org/issues/12292
-      @getc_mutex.synchronize { @closed = true }
+      @getc_mutex.synchronize { @closed = true } unless no_sync
 
       # Close the socket if possible
       @socket.close if @socket


### PR DESCRIPTION
Also fix `Gateway#stop` in the process.

`@ws.close` was still in use from pre-`gateway_rewrite` code, and was replaced with the new `close`.

In addition, the `connect_loop` method was continually setting `@should_reconnect = true` which caused errors, so this was moved outside the loop block.

Finally, `handle_close` assumed that the websocket would always close due to an error. Due to the potential for this behavior to be misleading, it now does nothing if `e` is `nil`. I suspect that you may prefer a different way of handling this.

Regression from the previous `Bot#stop` implementation: It is now impossible to use it to catch `SIGINT` and `SIGTERM`, since `close` relies on `.synchronize`, which cannot be called from a `trap` context.