### PR TITLE
Rework the fix for #88 without introducing caching errors

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1168,6 +1168,14 @@ module Discordrb
       JSON.parse(logs).map { |message| Message.new(message, @bot) }
     end
 
+    # Retrieves message history, but only message IDs for use with prune
+    # @note For internal use only
+    # @!visibility private
+    def history_ids(amount, before_id = nil, after_id = nil)
+      logs = API.channel_log(@bot.token, @id, amount, before_id, after_id)
+      JSON.parse(logs).map { |message| message['id'] }
+    end
+
     # Returns a single message from this channel's history by ID.
     # @param message_id [Integer] The ID of the message to retrieve.
     # @return [Message] the retrieved message.
@@ -1193,7 +1201,7 @@ module Discordrb
     def prune(amount)
       raise ArgumentError, 'Can only prune between 2 and 100 messages!' unless amount.between?(2, 100)
 
-      messages = history(amount).map(&:id)
+      messages = history_ids(amount)
       API.bulk_delete(@bot.token, @id, messages)
     end
 
@@ -1336,7 +1344,7 @@ module Discordrb
                     # directly because the bot may also send messages to the channel
                     Recipient.new(bot.user(data['author']['id'].to_i), @channel, bot)
                   else
-                    member = @channel.server.member(data['author']['id'].to_i, false)
+                    member = @channel.server.member(data['author']['id'].to_i)
                     Discordrb::LOGGER.warn("Member with ID #{data['author']['id']} not cached even though it should be.") unless member
                     member
                   end


### PR DESCRIPTION
Based on my testing, this eliminates most instances of `Member with ID [whatever] not cached even though it should be!`

I have now only been able to reproduce this log message when forcing the bot to interact with a message from a user who no longer shares any mutual servers with the bot.

Note: When making several Messages in a short period of time, I occasionally get an error from the gateway about the bot not having permission, which I traced back to the User API request. This may possibly be because of rate-limiting, but I am not sure. If necessary, I can rework this to only make a User API request if the user is not already cached.

Fixes #88 as well as fixes the (unreported on Github?) issue regarding user caching.