### PR TITLE
Additional methods to modify a Member's roles

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -488,7 +488,7 @@ module Discordrb
       add_role_ids = role_id_array(add)
       remove_role_ids = role_id_array(remove)
       old_role_ids = @roles.map(&:id)
-      new_role_ids = (old_role_ids.reject { |i| remove_role_ids.include?(i) } + add_role_ids).uniq
+      new_role_ids = (old_role_ids - remove_role_ids + add_role_ids).uniq
 
       API::Server.update_user(@bot.token, @server.id, @user.id, roles: new_role_ids)
     end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -481,6 +481,18 @@ module Discordrb
       API::Server.update_user(@bot.token, @server.id, @user.id, roles: role_ids)
     end
 
+    # Adds and removes roles from a member.
+    # @param add [Role, Array<Role>] The role(s) to add.
+    # @param remove [Role, Array<Role>] The role(s) to remove.
+    def modify_roles(add, remove)
+      add_role_ids = role_id_array(add)
+      remove_role_ids = role_id_array(remove)
+      old_role_ids = @roles.map(&:id)
+      new_role_ids = (old_role_ids.reject { |i| remove_role_ids.include?(i) } + add_role_ids).uniq
+
+      API::Server.update_user(@bot.token, @server.id, @user.id, roles: new_role_ids)
+    end
+
     # Adds one or more roles to this member.
     # @param role [Role, Array<Role>] The role(s) to add.
     def add_role(role)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -474,7 +474,7 @@ module Discordrb
       @roles.any? { |e| e.id == role }
     end
 
-    # Bulk sets a user's roles.
+    # Bulk sets a member's roles.
     # @param role [Role, Array<Role>] The role(s) to set.
     def roles=(role)
       role_ids = role_id_array(role)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -474,6 +474,13 @@ module Discordrb
       @roles.any? { |e| e.id == role }
     end
 
+    # Bulk sets a user's roles.
+    # @param role [Role, Array<Role>] The role(s) to set.
+    def roles=(role)
+      role_ids = role_id_array(role)
+      API::Server.update_user(@bot.token, @server.id, @user.id, roles: role_ids)
+    end
+
     # Adds one or more roles to this member.
     # @param role [Role, Array<Role>] The role(s) to add.
     def add_role(role)


### PR DESCRIPTION
Adds two methods:

- `roles=` to overwrite / bulk set all of a Member's roles at once

- `modify_roles` to add and remove specific roles in a single API call, this addresses the problem of not being able to `add_role` and `remove_role` within a single event because the cache hasn't been updated yet

Need to test it (tested the logic in `modify_roles` in `pry`), ~~but I'm feeling spicy so I'm opening a PR now~~. I think it should work fine though.

**Questions:**

- Is `modify_roles` an OK method name?

- Should `modify_roles` have default values, or leave the arguments as required and force the user to use `add_role` and `remove_role` if they only specify one? (Though I think it might work if they pass an empty array?)