### PR TITLE
add Channel#delete_messages

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1257,7 +1257,7 @@ module Discordrb
     def delete_messages(messages)
       raise ArgumentError, 'Can only delete between 2 and 100 messages!' unless messages.count.between?(2, 100)
 
-      messages.map! { |m| m.is_a?(Integer) ? m : m.id }
+      messages.map!(&:resolve_id)
       API::Channel.bulk_delete_messages(@bot.token, @id, messages)
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1251,6 +1251,16 @@ module Discordrb
       API::Channel.bulk_delete_messages(@bot.token, @id, messages)
     end
 
+    # Deletes a collection of messages
+    # @param messages [Array<Message, Integer>] the messages (or message IDs) to delete. Total must be an amount between 2 and 100 (Discord limitation)
+    # @raise [ArgumentError] if the amount of messages is not a value between 2 and 100
+    def delete_messages(messages)
+      raise ArgumentError, 'Can only delete between 2 and 100 messages!' unless messages.count.between?(2,100)
+
+      messages.map! { |m| m.is_a?(Integer) ? m : m.id }
+      API::Channel.bulk_delete_messages(@bot.token, @id, messages)
+    end
+
     # Updates the cached permission overwrites
     # @note For internal use only
     # @!visibility private

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1255,7 +1255,7 @@ module Discordrb
     # @param messages [Array<Message, Integer>] the messages (or message IDs) to delete. Total must be an amount between 2 and 100 (Discord limitation)
     # @raise [ArgumentError] if the amount of messages is not a value between 2 and 100
     def delete_messages(messages)
-      raise ArgumentError, 'Can only delete between 2 and 100 messages!' unless messages.count.between?(2,100)
+      raise ArgumentError, 'Can only delete between 2 and 100 messages!' unless messages.count.between?(2, 100)
 
       messages.map! { |m| m.is_a?(Integer) ? m : m.id }
       API::Channel.bulk_delete_messages(@bot.token, @id, messages)


### PR DESCRIPTION
allows for selective pruning of messages in a channel (instead of just last N messages) to make better use of the `bulk_delete` endpoint, for example, unless a `Member` has a certain role:

```ruby
command(:prune_unless_role, 
        required_permissions: [:manage_messages]) do |event|
  role = event.server.roles.find { |r| r.name == 'moderator' }
  messages = event.channel.history(100).map do |m|
    m.author.role?(role) ? nil : m
  end.compact
  event.channel.delete_messages(messages)
end
```