### PR TITLE
Small change to parameters display option

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -139,8 +139,9 @@ module Discordrb::Commands
           result = "**`#{command_name}`**: #{desc}"
           result += "\nUsage: `#{usage}`" if usage
           if parameters
-            result += "\nAccepted Parameters:"
-            parameters.each { |p| result += "\n    ``` #{p} ```" }
+            result += "\nAccepted Parameters:\n```"
+            parameters.each { |p| result += "\n#{p}" }
+            result += "```"
           end
           result
         else

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -140,7 +140,7 @@ module Discordrb::Commands
           result += "\nUsage: `#{usage}`" if usage
           if parameters
             result += "\nAccepted Parameters:"
-            parameters.each { |p| result += "\n    `#{p}`" }
+            parameters.each { |p| result += "\n    ``` #{p} ```" }
           end
           result
         else

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -141,7 +141,7 @@ module Discordrb::Commands
           if parameters
             result += "\nAccepted Parameters:\n```"
             parameters.each { |p| result += "\n#{p}" }
-            result += "```"
+            result += '```'
           end
           result
         else


### PR DESCRIPTION
This will display the parameters in a code block as opposed to inline like they were being displayed. This will allow the parameters section to have a consistent and uniform display even when the user uses extra newlines and indentation in their parameters array.