### PR TITLE
Fixed logger token redacting on debug mode

### DIFF
--- a/lib/discordrb/logger.rb
+++ b/lib/discordrb/logger.rb
@@ -91,7 +91,11 @@ module Discordrb
       timestamp = Time.now.strftime(LOG_TIMESTAMP_FORMAT)
 
       # Redact token if set
-      log = message.to_s.gsub(@token, 'REDACTED_TOKEN') if @token
+      log = if @token
+              message.to_s.gsub(@token, 'REDACTED_TOKEN')
+            else
+              message.to_s
+            end
 
       @streams.each do |stream|
         if @fancy && !stream.is_a?(File)

--- a/lib/discordrb/logger.rb
+++ b/lib/discordrb/logger.rb
@@ -91,13 +91,13 @@ module Discordrb
       timestamp = Time.now.strftime(LOG_TIMESTAMP_FORMAT)
 
       # Redact token if set
-      message.gsub!(@token, 'REDACTED_TOKEN') if @token
+      log = message.to_s.gsub(@token, 'REDACTED_TOKEN') if @token
 
       @streams.each do |stream|
         if @fancy && !stream.is_a?(File)
-          fancy_write(stream, message, mode, thread_name, timestamp)
+          fancy_write(stream, log, mode, thread_name, timestamp)
         else
-          simple_write(stream, message, mode, thread_name, timestamp)
+          simple_write(stream, log, mode, thread_name, timestamp)
         end
       end
     end


### PR DESCRIPTION
Fixes:
Cases of `#gsub!` on a Hash causing it to fail instead of log.
Cases of substituting the outgoing message token causing the authentication to break.