### PR TITLE
Fixed overwriting existing #on

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -682,8 +682,6 @@ module Discordrb
       update_profile_status_setting('online')
     end
 
-    alias_method(:on, :online)
-
     # Sets the user status setting to Idle.
     # @note Only usable on User accounts.
     def idle


### PR DESCRIPTION
Prevented people from being able to get `Member` using `Profile#on`