### PR TITLE
Add 'channels' attribute to commands and command_bot

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -174,6 +174,7 @@ module Discordrb::Commands
       debug("Executing command #{name} with arguments #{arguments}")
       return unless @commands
       command = @commands[name]
+      return unless channels?(event.channel, command.attributes[:channels])
       unless command
         event.respond @attributes[:command_doesnt_exist_message].gsub('%command%', name.to_s) if @attributes[:command_doesnt_exist_message]
         return
@@ -299,6 +300,20 @@ module Discordrb::Commands
         end
       else
         member.role?(role)
+      end
+    end
+
+    def channels?(channel, channels)
+      return true if channels.empty?
+      channels.any? do |c|
+        if c.is_a? String
+          # Make sure to remove the "#" from channel names in case it was specified
+          c.delete('#') == channel.name
+        elsif c.is_a? Fixnum
+          c == channel.id
+        else
+          c == channel
+        end
       end
     end
 

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -174,11 +174,11 @@ module Discordrb::Commands
       debug("Executing command #{name} with arguments #{arguments}")
       return unless @commands
       command = @commands[name]
-      return unless channels?(event.channel, command.attributes[:channels])
       unless command
         event.respond @attributes[:command_doesnt_exist_message].gsub('%command%', name.to_s) if @attributes[:command_doesnt_exist_message]
         return
       end
+      return unless channels?(event.channel, command.attributes[:channels])
       if permission?(event.author, command.attributes[:permission_level], event.server) &&
          required_permissions?(event.author, command.attributes[:required_permissions], event.channel) &&
          required_roles?(event.author, command.attributes[:required_roles])

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -50,6 +50,8 @@ module Discordrb::Commands
     #   command. Default is false.
     # @option attributes [true, false] :webhook_commands Whether messages sent by webhooks are allowed to trigger
     #   commands. Default is true.
+    # @option attributes [Array<String, Integer, Channel>] :channels The channels this command bot accepts commands on.
+    #   Superseded if a command has a 'channels' attribute.
     # @option attributes [String] :previous Character that should designate the result of the previous command in
     #   a command chain (see :advanced_functionality). Default is '~'.
     # @option attributes [String] :chain_delimiter Character that should designate that a new command begins in the
@@ -99,6 +101,8 @@ module Discordrb::Commands
 
         # Webhooks allowed to trigger commands
         webhook_commands: attributes[:webhook_commands].nil? ? true : attributes[:webhook_commands],
+
+        channels: attributes[:channels] || [],
 
         # All of the following need to be one character
         # String to designate previous result in command chain
@@ -174,6 +178,8 @@ module Discordrb::Commands
       debug("Executing command #{name} with arguments #{arguments}")
       return unless @commands
       command = @commands[name]
+      return unless channels?(event.channel, @attributes[:channels]) ||
+                    (command && !command.attributes[:channels].nil?)
       unless command
         event.respond @attributes[:command_doesnt_exist_message].gsub('%command%', name.to_s) if @attributes[:command_doesnt_exist_message]
         return
@@ -304,7 +310,7 @@ module Discordrb::Commands
     end
 
     def channels?(channel, channels)
-      return true if channels.empty?
+      return true if channels.nil? || channels.empty?
       channels.any? do |c|
         if c.is_a? String
           # Make sure to remove the "#" from channel names in case it was specified

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -24,7 +24,7 @@ module Discordrb::Commands
     #   should be required to use this command. See {Discordrb::Permissions::Flags} for a list.
     # @option attributes [Array<Role>, Array<#resolve_id>] :required_roles Roles that user should have to use this command.
     # @option attributes [Array<String, Integer, Channel>] :channels The channels that this command can be used on. An
-    #   empty array indicates it can be used on any channel.
+    #   empty array indicates it can be used on any channel. Supersedes the command bot attribute.
     # @option attributes [true, false] :chain_usable Whether this command is able to be used inside of a command chain
     #   or sub-chain. Typically used for administrative commands that shouldn't be done carelessly.
     # @option attributes [true, false] :help_available Whether this command is visible in the help command. See the

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -23,6 +23,7 @@ module Discordrb::Commands
     # @option attributes [Array<Symbol>] :required_permissions Discord action permissions (e.g. `:kick_members`) that
     #   should be required to use this command. See {Discordrb::Permissions::Flags} for a list.
     # @option attributes [Array<Role>, Array<#resolve_id>] :required_roles Roles that user should have to use this command.
+    # @option attributes [Array<String, Integer, Channel>] :channels The channels that this command can be used on.
     # @option attributes [true, false] :chain_usable Whether this command is able to be used inside of a command chain
     #   or sub-chain. Typically used for administrative commands that shouldn't be done carelessly.
     # @option attributes [true, false] :help_available Whether this command is visible in the help command. See the

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -23,7 +23,8 @@ module Discordrb::Commands
     # @option attributes [Array<Symbol>] :required_permissions Discord action permissions (e.g. `:kick_members`) that
     #   should be required to use this command. See {Discordrb::Permissions::Flags} for a list.
     # @option attributes [Array<Role>, Array<#resolve_id>] :required_roles Roles that user should have to use this command.
-    # @option attributes [Array<String, Integer, Channel>] :channels The channels that this command can be used on.
+    # @option attributes [Array<String, Integer, Channel>] :channels The channels that this command can be used on. An
+    #   empty array indicates it can be used on any channel.
     # @option attributes [true, false] :chain_usable Whether this command is able to be used inside of a command chain
     #   or sub-chain. Typically used for administrative commands that shouldn't be done carelessly.
     # @option attributes [true, false] :help_available Whether this command is visible in the help command. See the

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -26,7 +26,7 @@ module Discordrb::Commands
         required_roles: attributes[:required_roles] || [],
 
         # Channels this command can be used on
-        channels: attributes[:channels] || [],
+        channels: attributes[:channels] || nil,
 
         # Whether this command is usable in a command chain
         chain_usable: attributes[:chain_usable].nil? ? true : attributes[:chain_usable],

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -25,6 +25,9 @@ module Discordrb::Commands
         # Roles required to use this command
         required_roles: attributes[:required_roles] || [],
 
+        # Channels this command can be used on
+        channels: attributes[:channels] || [],
+
         # Whether this command is usable in a command chain
         chain_usable: attributes[:chain_usable].nil? ? true : attributes[:chain_usable],
 


### PR DESCRIPTION
Adds an attribute 'channels' to commands that is for specifying the only channels that a command can be run on. Specified as any mix of channel names, id's and channel objects themselves.