### PR TITLE
Allow the current game state to be cleared

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -465,7 +465,7 @@ module Discordrb
       @streamurl = url
       type = url ? 1 : nil
 
-      game_obj = game || url ? { name: game, url: url, type: type } : nil
+      game_obj = { name: game, url: url, type: type }
       @gateway.send_status_update(status, since, game_obj, afk)
     end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -1,0 +1,196 @@
+require 'discordrb'
+
+RSpec.describe Discordrb::Bot do
+  let(:gateway) { instance_double(Discordrb::Gateway) }
+  let(:token) { '1234567abcdef' }
+  let(:instance) { described_class.new(token: token) }
+
+  before do
+    instance.instance_variable_set(:@gateway, gateway)
+    allow(gateway).to receive(:open?).and_return(true)
+  end
+
+  describe 'when changing the current state' do
+    describe 'via #update_status' do
+      context 'when changing only the game' do
+        it 'attempts to send the new game' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:online,
+                  anything,
+                  { name: 'new game', url: nil, type: nil },
+                  anything)
+
+          instance.update_status(:online, 'new game', nil)
+        end
+      end
+
+      context 'when changing only the stream url' do
+        it 'attempts to send the new stream url' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:online,
+                  anything,
+                  { name: nil, url: 'new stream url', type: 1 },
+                  anything)
+
+          instance.update_status(:online, nil, 'new stream url')
+        end
+      end
+
+      context 'when changing both the game and the stream url' do
+        it 'attempts to send the new game object' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:online,
+                  anything,
+                  { name: 'gamegame', url: 'new stream url', type: 1 },
+                  anything)
+
+          instance.update_status(:online, 'gamegame', 'new stream url')
+        end
+      end
+    end
+
+    describe 'via #game=' do
+      it 'attempts to send the new game' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:online,
+                anything,
+                { name: 'new game', url: nil, type: nil },
+                anything)
+
+        instance.game = 'new game'
+      end
+
+      context 'when clearing out the currently set game' do
+        it 'sends a nil value upstream' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:online,
+                  anything,
+                  { name: nil, url: nil, type: nil },
+                  anything)
+
+          instance.game = nil
+        end
+      end
+    end
+
+    describe 'via #stream' do
+      it 'attempts to send the new stream url' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:online,
+                anything,
+                { name: 'stream', url: 'url', type: 1 },
+                anything)
+
+        instance.stream('stream', 'url')
+      end
+
+      context 'when clearing out the currently set stream' do
+        it 'sends a nil value upstream' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:online,
+                  anything,
+                  { name: nil, url: nil, type: nil },
+                  anything)
+
+          instance.stream(nil, nil)
+        end
+      end
+    end
+
+    describe 'via #online' do
+      it 'attempts to send the idle state' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:idle, anything, anything, anything)
+
+        instance.idle
+      end
+
+      context "when there's a game set" do
+        before { allow(gateway).to receive(:send_status_update) }
+        before { instance.game = 'my game' }
+
+        it 'resends the current game' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:idle,
+                  anything,
+                  { name: 'my game', url: nil, type: nil },
+                  anything)
+
+          instance.idle
+        end
+      end
+    end
+
+    describe 'via #idle' do
+      it 'attempts to send the idle state' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:online, anything, anything, anything)
+
+        instance.online
+      end
+
+      context "when there's a game set" do
+        before { allow(gateway).to receive(:send_status_update) }
+        before { instance.game = 'my game' }
+
+        it 'resends the current game' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:idle,
+                  anything,
+                  { name: 'my game', url: nil, type: nil },
+                  anything)
+
+          instance.idle
+        end
+      end
+    end
+
+    describe 'via #dnd' do
+      it 'attempts to send the idle state' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:dnd, anything, anything, anything)
+
+        instance.dnd
+      end
+
+      context "when there's a game set" do
+        before { allow(gateway).to receive(:send_status_update) }
+        before { instance.game = 'my game' }
+
+        it 'resends the current game' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:dnd,
+                  anything,
+                  { name: 'my game', url: nil, type: nil },
+                  anything)
+
+          instance.dnd
+        end
+      end
+    end
+
+    describe 'via #invisible' do
+      it 'attempts to send the idle state' do
+        expect(gateway).to receive(:send_status_update)
+          .with(:invisible, anything, anything, anything)
+
+        instance.invisible
+      end
+
+      context "when there's a game set" do
+        before { allow(gateway).to receive(:send_status_update) }
+        before { instance.game = 'my game' }
+
+        it 'resends the current game' do
+          expect(gateway).to receive(:send_status_update)
+            .with(:invisible,
+                  anything,
+                  { name: 'my game', url: nil, type: nil },
+                  anything)
+
+          instance.invisible
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Context
----------

According to
https://discordapp.com/developers/docs/topics/gateway#gateway-status-update
it's possible to send a `null` value in place of a `game` object when
attempting to update the game's state. However, that has the effect of
*not* updating the current state. In other words, sending `null` will
keep the current state unchanged.

Problem
----------

It's currently impossible to reset the current game state. Steps to
reproduce:

1. change the game state via `bot.game="new game"`
2. the state is changed on discord
3. clear the state out via `bot.game = nil`
4. expected: the game state clears -- what happens instead: nothing

The reason is that we want to explicitely set `game.name = null` rather
than just `game = null` in the json we send to the server.

The fix
----------

I thought about using different approaches such as forcing to send the
payload if either `game` or `url` is different from their current state
set in the instance variables (respectively `@game` and `@streamurl`).
However that doesn't work if you want to reset the state at startup
since we have no knowledge of what those attributes were before.
The current fix always sends the payload upstream. It's not that many
bytes anyway.

Also I'm a bit confused by the `url` attribute. I can't find it anywhere
on the discord docs. Perhaps it's a legacy thing? Anyway I'm leaving it
unchanged for now.

Please let me know if this makes sense.