### PR TITLE
Add ignoring bot accounts as Bot param

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -91,11 +91,12 @@ module Discordrb
     # @param num_shards [Integer] The total number of shards that should be running. See
     #   https://github.com/hammerandchisel/discord-api-docs/issues/17 for how to do sharding.
     # @param redact_token [true, false] Whether the bot should redact the token in logs. Default is true.
+    # @param ignore_bots [true, false] Whether the bot should ignore Bot accounts or not. Default is false.
     def initialize(
         log_mode: :normal,
         token: nil, client_id: nil, application_id: nil,
         type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
-        shard_id: nil, num_shards: nil, redact_token: true
+        shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false
     )
 
       LOGGER.mode = if log_mode.is_a? TrueClass # Specifically check for `true` because people might not have updated yet
@@ -131,6 +132,7 @@ module Discordrb
       @should_connect_to_voice = {}
 
       @ignored_ids = Set.new
+      @ignore_bots = ignore_bots
 
       @event_threads = []
       @current_thread = 0
@@ -914,6 +916,11 @@ module Discordrb
       when :MESSAGE_CREATE
         if ignored?(data['author']['id'].to_i)
           debug("Ignored author with ID #{data['author']['id']}")
+          return
+        end
+
+        if @ignore_bots and user(data['author']['id']).bot_account?
+          debug("Ignored Bot account with ID #{data['author']['id']}")
           return
         end
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -919,7 +919,7 @@ module Discordrb
           return
         end
 
-        if @ignore_bots && user(data['author']['bot'])
+        if @ignore_bots && data['author']['bot']
           debug("Ignored Bot account with ID #{data['author']['id']}")
           return
         end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -91,7 +91,7 @@ module Discordrb
     # @param num_shards [Integer] The total number of shards that should be running. See
     #   https://github.com/hammerandchisel/discord-api-docs/issues/17 for how to do sharding.
     # @param redact_token [true, false] Whether the bot should redact the token in logs. Default is true.
-    # @param ignore_bots [true, false] Whether the bot should ignore Bot accounts or not. Default is false.
+    # @param ignore_bots [true, false] Whether the bot should ignore bot accounts or not. Default is false.
     def initialize(
         log_mode: :normal,
         token: nil, client_id: nil, application_id: nil,
@@ -919,7 +919,7 @@ module Discordrb
           return
         end
 
-        if @ignore_bots && user(data['author']['id']).bot_account?
+        if @ignore_bots && user(data['author']['bot'])
           debug("Ignored Bot account with ID #{data['author']['id']}")
           return
         end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -919,7 +919,7 @@ module Discordrb
           return
         end
 
-        if @ignore_bots and user(data['author']['id']).bot_account?
+        if @ignore_bots && user(data['author']['id']).bot_account?
           debug("Ignored Bot account with ID #{data['author']['id']}")
           return
         end

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -66,7 +66,7 @@ module Discordrb::Commands
     #   :advanced_functionality). Default is '"'.
     # @option attributes [String] :quote_end Character that should end a quoted string (see
     #   :advanced_functionality). Default is '"'.
-    # @option attributes [true, false] :ignore_bots Whether the bot should ignore Bot accounts or not. Default is false.
+    # @option attributes [true, false] :ignore_bots Whether the bot should ignore bot accounts or not. Default is false.
     def initialize(attributes = {})
       super(
         log_mode: attributes[:log_mode],

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -66,6 +66,7 @@ module Discordrb::Commands
     #   :advanced_functionality). Default is '"'.
     # @option attributes [String] :quote_end Character that should end a quoted string (see
     #   :advanced_functionality). Default is '"'.
+    # @option attributes [true, false] :ignore_bots Whether the bot should ignore Bot accounts or not. Default is false.
     def initialize(attributes = {})
       super(
         log_mode: attributes[:log_mode],
@@ -79,7 +80,8 @@ module Discordrb::Commands
         parse_self: attributes[:parse_self],
         shard_id: attributes[:shard_id],
         num_shards: attributes[:num_shards],
-        redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true)
+        redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
+        ignore_bots: attributes[:ignore_bots])
 
       @prefix = attributes[:prefix]
       @attributes = {


### PR DESCRIPTION
Not sure if we should also add it as command param. (Also not sure, if this is how you would like it implemented, probably not...)
