### PR TITLE
Add basic reaction support

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1807,8 +1807,7 @@ module Discordrb
     # @return [Integer] the amount of users who have reacted with this reaction
     attr_reader :count
 
-    # TODO: I have no idea what this is.
-    # @return [true, false] me
+    # @return [true, false] whether the current bot or user used this reaction
     attr_reader :me
 
     # @return [Integer] the ID of the emoji, if it was custom

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1815,6 +1815,7 @@ module Discordrb
 
     # @return [true, false] whether the current bot or user used this reaction
     attr_reader :me
+    alias_method :me?, :me
 
     # @return [Integer] the ID of the emoji, if it was custom
     attr_reader :id

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1820,7 +1820,7 @@ module Discordrb
     def initialize(data)
       @count = data['count']
       @me = data['me']
-      @id = data['emoji']['id']
+      @id = data['emoji']['id'].to_i
       @name = data['emoji']['name']
     end
   end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1799,7 +1799,7 @@ module Discordrb
     # Returns the reactions made by the current bot or user
     # @return [Array<Reaction>] the reactions
     def my_reactions
-      @reactions.select { |r| r.me }
+      @reactions.select(&:me)
     end
 
     # The inspect method is overwritten to give more useful output

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1796,6 +1796,11 @@ module Discordrb
       @reactions.any?
     end
 
+    # Returns the reactions made by the current bot or user
+    def my_reactions
+      reactions.select { |r| r.me }
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1624,6 +1624,9 @@ module Discordrb
     # @return [Array<Embed>] the embed objects contained in this message.
     attr_reader :embeds
 
+    # @return [Array<Reaction>] the reaction objects attached to this message
+    attr_reader :reactions
+
     # @return [true, false] whether the message used Text-To-Speech (TTS) or not.
     attr_reader :tts
     alias_method :tts?, :tts
@@ -1706,6 +1709,8 @@ module Discordrb
 
       @embeds = []
       @embeds = data['embeds'].map { |e| Embed.new(e, self) } if data['embeds']
+
+      @reactions = data['reactions'].map { |e| Reaction.new(e) } if data['reactions']
     end
 
     # Replies to this message with the specified content.
@@ -1785,9 +1790,38 @@ module Discordrb
       return true unless emoji.empty?
     end
 
+    # Check if any reactions got used in this message
+    # @return [true, false] whether or not this message has reactions
+    def reactions?
+      @reactions.any?
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"
+    end
+  end
+
+  # A reaction to a message
+  class Reaction
+    # @return [Integer] the amount of users who have reacted with this reaction
+    attr_reader :count
+
+    # TODO: I have no idea what this is.
+    # @return [true, false] me
+    attr_reader :me
+
+    # @return [Integer] the ID of the emoji, if it was custom
+    attr_reader :id
+
+    # @return [String] the name or unicode representation of the emoji
+    attr_reader :name
+
+    def initialize(data)
+      @count = data['count']
+      @me = data['me']
+      @id = data['emoji']['id']
+      @name = data['emoji']['name']
     end
   end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1799,7 +1799,7 @@ module Discordrb
     # Returns the reactions made by the current bot or user
     # @return [Array<Reaction>] the reactions
     def my_reactions
-      reactions.select { |r| r.me }
+      @reactions.select { |r| r.me }
     end
 
     # The inspect method is overwritten to give more useful output

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1797,6 +1797,7 @@ module Discordrb
     end
 
     # Returns the reactions made by the current bot or user
+    # @return [Array<Reaction>] the reactions
     def my_reactions
       reactions.select { |r| r.me }
     end


### PR DESCRIPTION
Built from inspecting a `Message` payload

```json
  "reactions": [
    {
      "count": 1,
      "me": false,
      "emoji": {
        "id": null,
        "name": "🔥"
      }
    },
    {
      "count": 1,
      "me": false,
      "emoji": {
        "id": null,
        "name": "🤔"
      }
    },
    {
      "count": 1,
      "me": false,
      "emoji": {
        "id": "243348509850468352",
        "name": "weeb"
      }
    }
  ],
```

I have no idea what `"me"` is - I'm assuming (almost certain) it's whether or not the calling user used that reaction, but I can't test this at the moment. Not useful unless an endpoint for bots to make reactions is found / documented, or you're using a selfbot.

Some child objects of `Message` point back at the message they are attached to. I don't think it's worth doing here for something as simple as reactions, and the typical use case for these methods.