### PR TITLE
Add REST support for reactions and abstractions for Message

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -150,6 +150,17 @@ module Discordrb::API::Channel
     )
   end
 
+  # Deletes all reactions on a message from all clients
+  def delete_all_reactions(token, channel_id, message_id)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :delete,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions",
+      Authorization: token
+    )
+  end
+
   # Update a channels permission for a role or member
   # https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions
   def update_permission(token, channel_id, overwrite_id, allow, deny, type)

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -162,6 +162,18 @@ module Discordrb::API::Channel
     )
   end
 
+  # Delete another client's reaction on a message
+  def delete_user_reaction(token, channel_id, message_id, emoji, user_id)
+    emoji = URI.encode(emoji)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :delete,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/#{user_id}",
+      Authorization: token
+    )
+  end
+
   # Get a list of clients who reacted with a specific reaction on a message
   def get_reactions(token, channel_id, message_id, emoji)
     emoji = URI.encode(emoji)

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -133,10 +133,8 @@ module Discordrb::API::Channel
     )
   end
 
-  # TODO: Insert docs links once they are pushed to master
-  # for reactions endpoints
-
   # Create a reaction on a message using this client
+  # https://discordapp.com/developers/docs/resources/channel#create-reaction
   def create_reaction(token, channel_id, message_id, emoji)
     emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -151,6 +149,7 @@ module Discordrb::API::Channel
   end
 
   # Delete this client's own reaction on a message
+  # https://discordapp.com/developers/docs/resources/channel#delete-own-reaction
   def delete_own_reaction(token, channel_id, message_id, emoji)
     emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -163,6 +162,7 @@ module Discordrb::API::Channel
   end
 
   # Delete another client's reaction on a message
+  # https://discordapp.com/developers/docs/resources/channel#delete-user-reaction
   def delete_user_reaction(token, channel_id, message_id, emoji, user_id)
     emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -175,6 +175,7 @@ module Discordrb::API::Channel
   end
 
   # Get a list of clients who reacted with a specific reaction on a message
+  # https://discordapp.com/developers/docs/resources/channel#get-reactions
   def get_reactions(token, channel_id, message_id, emoji)
     emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
@@ -187,6 +188,7 @@ module Discordrb::API::Channel
   end
 
   # Deletes all reactions on a message from all clients
+  # https://discordapp.com/developers/docs/resources/channel#delete-all-reactions
   def delete_all_reactions(token, channel_id, message_id)
     Discordrb::API.request(
       :channels_cid_messages_mid,

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -150,6 +150,18 @@ module Discordrb::API::Channel
     )
   end
 
+  # Get a list of clients who reacted with a specific reaction on a message
+  def get_reactions(token, channel_id, message_id, emoji)
+    emoji = URI.encode(emoji)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :get,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}",
+      Authorization: token
+    )
+  end
+
   # Deletes all reactions on a message from all clients
   def delete_all_reactions(token, channel_id, message_id)
     Discordrb::API.request(

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -150,6 +150,18 @@ module Discordrb::API::Channel
     )
   end
 
+  # Delete this client's own reaction on a message
+  def delete_own_reaction(token, channel_id, message_id, emoji)
+    emoji = URI.encode(emoji)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :delete,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me",
+      Authorization: token
+    )
+  end
+
   # Get a list of clients who reacted with a specific reaction on a message
   def get_reactions(token, channel_id, message_id, emoji)
     emoji = URI.encode(emoji)

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -133,6 +133,23 @@ module Discordrb::API::Channel
     )
   end
 
+  # TODO: Insert docs links once they are pushed to master
+  # for reactions endpoints
+
+  # Create a reaction on a message using this client
+  def create_reaction(token, channel_id, message_id, emoji)
+    emoji = URI.encode(emoji)
+    Discordrb::API.request(
+      :channels_cid_messages_mid,
+      channel_id,
+      :put,
+      "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}/reactions/#{emoji}/@me",
+      nil,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Update a channels permission for a role or member
   # https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions
   def update_permission(token, channel_id, overwrite_id, allow, deny, type)

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -138,7 +138,7 @@ module Discordrb::API::Channel
 
   # Create a reaction on a message using this client
   def create_reaction(token, channel_id, message_id, emoji)
-    emoji = URI.encode(emoji)
+    emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
@@ -152,7 +152,7 @@ module Discordrb::API::Channel
 
   # Delete this client's own reaction on a message
   def delete_own_reaction(token, channel_id, message_id, emoji)
-    emoji = URI.encode(emoji)
+    emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
@@ -164,7 +164,7 @@ module Discordrb::API::Channel
 
   # Delete another client's reaction on a message
   def delete_user_reaction(token, channel_id, message_id, emoji, user_id)
-    emoji = URI.encode(emoji)
+    emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
@@ -176,7 +176,7 @@ module Discordrb::API::Channel
 
   # Get a list of clients who reacted with a specific reaction on a message
   def get_reactions(token, channel_id, message_id, emoji)
-    emoji = URI.encode(emoji)
+    emoji = URI.encode(emoji) unless emoji.ascii_only?
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1823,6 +1823,14 @@ module Discordrb
       response.map { |d| User.new(d, @bot) }
     end
 
+    # Deletes a reaction made by a user on this message
+    # @param [User, #resolve_id] the user who used this reaction
+    # @param [String, Emoji] the reaction to remove
+    def delete_reaction(user, reaction)
+      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      API::Channel.delete_user_reaction(@bot.token, @channel.id, @id, reaction, user.resolve_id)
+    end
+
     # Removes all reactions from this message
     def delete_all_reactions
       API::Channel.delete_all_reactions(@bot.token, @channel.id, @id)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1814,6 +1814,15 @@ module Discordrb
       nil
     end
 
+    # Returns the list of users who reacted with a certain reaction
+    # @param [String, Emoji] the unicode emoji or an Emoji
+    # @return [Array<User>] the users who used this reaction
+    def reacted_with(reaction)
+      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      response = JSON.parse(API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction))
+      response.map { |d| User.new(d, @bot) }
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1806,6 +1806,14 @@ module Discordrb
       @reactions.select(&:me)
     end
 
+    # Reacts to a message
+    # @param [String, Emoji] the unicode emoji or an Emoji
+    def react(reaction)
+      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      API::Channel.create_reaction(@bot.token, @channel.id, @id, reaction)
+      nil
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1823,6 +1823,11 @@ module Discordrb
       response.map { |d| User.new(d, @bot) }
     end
 
+    # Removes all reactions from this message
+    def delete_all_reactions
+      API::Channel.delete_all_reactions(@bot.token, @channel.id, @id)
+    end
+
     # The inspect method is overwritten to give more useful output
     def inspect
       "<Message content=\"#{@content}\" id=#{@id} timestamp=#{@timestamp} author=#{@author} channel=#{@channel}>"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1831,6 +1831,13 @@ module Discordrb
       API::Channel.delete_user_reaction(@bot.token, @channel.id, @id, reaction, user.resolve_id)
     end
 
+    # Delete's this clients reaction on this message
+    # @param [String, Emoji] the reaction to remove
+    def delete_own_reaction(reaction)
+      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      API::Channel.delete_own_reaction(@bot.token, @channel.id, @id, reaction)
+    end
+
     # Removes all reactions from this message
     def delete_all_reactions
       API::Channel.delete_all_reactions(@bot.token, @channel.id, @id)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1808,11 +1808,13 @@ module Discordrb
 
     # Reacts to a message
     # @param [String, Emoji] the unicode emoji or an Emoji
-    def react(reaction)
+    def create_reaction(reaction)
       reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
       API::Channel.create_reaction(@bot.token, @channel.id, @id, reaction)
       nil
     end
+
+    alias_method :react, :create_reaction
 
     # Returns the list of users who reacted with a certain reaction
     # @param [String, Emoji] the unicode emoji or an Emoji

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1807,9 +1807,9 @@ module Discordrb
     end
 
     # Reacts to a message
-    # @param [String, Emoji] the unicode emoji or an Emoji
+    # @param [String, #to_reaction] the unicode emoji, Emoji, or GlobalEmoji
     def create_reaction(reaction)
-      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       API::Channel.create_reaction(@bot.token, @channel.id, @id, reaction)
       nil
     end
@@ -1817,26 +1817,26 @@ module Discordrb
     alias_method :react, :create_reaction
 
     # Returns the list of users who reacted with a certain reaction
-    # @param [String, Emoji] the unicode emoji or an Emoji
+    # @param [String, #to_reaction] the unicode emoji, Emoji, or GlobalEmoji
     # @return [Array<User>] the users who used this reaction
     def reacted_with(reaction)
-      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       response = JSON.parse(API::Channel.get_reactions(@bot.token, @channel.id, @id, reaction))
       response.map { |d| User.new(d, @bot) }
     end
 
     # Deletes a reaction made by a user on this message
     # @param [User, #resolve_id] the user who used this reaction
-    # @param [String, Emoji] the reaction to remove
+    # @param [String, #to_reaction] the reaction to remove
     def delete_reaction(user, reaction)
-      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       API::Channel.delete_user_reaction(@bot.token, @channel.id, @id, reaction, user.resolve_id)
     end
 
     # Delete's this clients reaction on this message
-    # @param [String, Emoji] the reaction to remove
+    # @param [String, #to_reaction] the reaction to remove
     def delete_own_reaction(reaction)
-      reaction = "#{reaction.name}:#{reaction.id}" if reaction.is_a? Emoji
+      reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)
       API::Channel.delete_own_reaction(@bot.token, @channel.id, @id, reaction)
     end
 
@@ -1906,6 +1906,11 @@ module Discordrb
     alias_method :use, :mention
     alias_method :to_s, :mention
 
+    # @return [String] the layout to use this emoji in a reaction
+    def to_reaction
+      "#{@name}:#{@id}"
+    end
+
     # @return [String] the icon URL of the emoji
     def icon_url
       API.emoji_icon_url(@id)
@@ -1954,6 +1959,11 @@ module Discordrb
 
     alias_method :use, :mention
     alias_method :to_s, :mention
+
+    # @return [String] the layout to use this emoji in a reaction
+    def to_reaction
+      "#{@name}:#{@id}"
+    end
 
     # @return [String] the icon URL of the emoji
     def icon_url


### PR DESCRIPTION
These docs aren't live yet but can be viewed [here](https://github.com/hammerandchisel/discord-api-docs/blob/master/docs/resources/Channel.md#create-reaction--put-channelschanneliddocs_channelchannel-objectsmessagesmessageiddocs_channelmessage-objectreactionsemojidocs_channelemoji-structureme).

I added abstractions to `Message` that covers each of these endpoints. Not sure if there's anything else that would be more helpful.

I added `#to_reaction` to `Emoji` and `GlobalEmoji` in favor of interpolating the layout inside of the method. Hope that's okay, `#to_s` obviously can't facilitate this because of the leading /trailing `<:` `>`