### PR TITLE
Typing events can be responded to like any other message

### DIFF
--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -62,6 +62,7 @@ module Discordrb::Events
   # Event raised when a text message is sent to a channel
   class MessageEvent < Event
     include Respondable
+
     # @return [Message] the message which triggered this event.
     attr_reader :message
 
@@ -234,6 +235,7 @@ module Discordrb::Events
   # A subset of MessageEvent that only contains a message ID and a channel
   class MessageIDEvent < Event
     include Respondable
+
     # @return [Integer] the ID associated with this event
     attr_reader :id
 

--- a/lib/discordrb/events/typing.rb
+++ b/lib/discordrb/events/typing.rb
@@ -5,6 +5,7 @@ require 'discordrb/events/generic'
 module Discordrb::Events
   # Event raised when a user starts typing
   class TypingEvent < Event
+    include Respondable
     # @return [Channel] the channel on which a user started typing.
     attr_reader :channel
 

--- a/lib/discordrb/events/typing.rb
+++ b/lib/discordrb/events/typing.rb
@@ -6,6 +6,7 @@ module Discordrb::Events
   # Event raised when a user starts typing
   class TypingEvent < Event
     include Respondable
+
     # @return [Channel] the channel on which a user started typing.
     attr_reader :channel
 


### PR DESCRIPTION
This change was spurred by 'drewajp':

<img width="772" alt="screen shot 2016-11-14 at 12 56 07 am" src="https://cloud.githubusercontent.com/assets/1882/20257202/34ed48bc-aa05-11e6-9501-bb4c80728bc9.png">

A reference code example:

```ruby
require 'discordrb'

bot = Discordrb::Bot.new token: ENV['DISCORD_TOKEN'], client_id: ENV['DISCORD_APPLICATION_ID']

bot.typing do |event|
  if event.user.id == ENV['DISCORD_ADMIN_USER_ID'].to_i
    event.respond %Q{You started typing at #{event.timestamp}}
  end
end

bot.run
```

When running this, the bot sent

```plain
You started typing at 2016-11-14 07:49:59 +0000
```

In the channel I started typing in. Tested it on two different Discord servers, one channel named `#general`, one not.