### PR TITLE
Limits commands in help list

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -152,7 +152,7 @@ module Discordrb::Commands
           result
         else
           available_commands = @commands.values.reject do |c|
-            !c.attributes[:help_available] || !required_roles?(event.author, c.attributes[:required_roles]) || !required_permissions?(event.author, c.attributes[:required_permissions], event.channel)
+            !c.attributes[:help_available] || !required_roles?(event.user, c.attributes[:required_roles]) || !required_permissions?(event.user, c.attributes[:required_permissions], event.channel)
           end
           case available_commands.length
           when 0..5

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -151,7 +151,9 @@ module Discordrb::Commands
           end
           result
         else
-          available_commands = @commands.values.reject { |c| !c.attributes[:help_available] }
+          available_commands = @commands.values.reject do |c|
+            !c.attributes[:help_available] || !required_roles?(event.author, c.attributes[:required_roles]) || !required_permissions?(event.author, c.attributes[:required_permissions], event.channel)
+          end
           case available_commands.length
           when 0..5
             available_commands.reduce "**List of commands:**\n" do |memo, c|


### PR DESCRIPTION
This limits the commands in the help list to only show commands a user has the correct role or permissions to access. This was done by https://github.com/z64/ (Lune), but he had no intention of submitting a pull request, and told me to mention him if I submitted a pull for it. It does not support permission_level.