### PR TITLE
Default non-streaming game type to 0

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -461,7 +461,7 @@ module Discordrb
       @game = game
       @status = status
       @streamurl = url
-      type = url ? 1 : nil
+      type = url ? 1 : 0
 
       game_obj = game || url ? { name: game, url: url, type: type } : nil
       @gateway.send_status_update(status, since, game_obj, afk)


### PR DESCRIPTION
Game types should either be sent as 0 (Playing) or 1 (Streaming).

Although the expectation is that libraries might want to assume that a
nil game type value is 0 (due to lack of validation on Discord's side),
a type should still be sent where possible for those that don't.

There is precedent in a few other libraries I looked at for defining a
Game that is not streaming as having a type value 0:

- [discord.net]
- [discord4j]
- [dscord]

Two pieces of events received with type 0 for a game, one from the
official client and one from a bot with another library:

Official client:
```json
{"t":"PRESENCE_UPDATE","s":24,"op":0,"d":{"user":{"id":"[redacted ID]"},"status":"online","roles":[],"nick":null,"guild_id":"81384788765712384","game":{"type":0,"name":"Arma 3"}}}
```

Bot:
```json
{"t":"PRESENCE_UPDATE","s":264,"op":0,"d":{"user":{"id":"[redacted ID]"},"status":"online","roles":["159592059873787904"],"nick":null,"guild_id":"81384788765712384","game":{"url":null,"type":0,"name":"OFF | Shard 0/2"}}}
```

This fixes decoding issues in other libs (which has been resolved, but
regardless), such as:

```
WARN:discord: Error decoding: {"t":"PRESENCE_UPDATE","s":4093,"op":0,"d":{"user":{"id":"213450769276338177"},"status":"online","roles":["232581370147373056","228906282805886987"],"nick":"festive mana","guild_id":"198101180180594688","game":{"url":null,"type":null,"name":"with Lune"}}}
```

[discord.net]: https://github.com/RogueException/Discord.Net/blob/cf3aa40c8ab110ba8d425b1e2dbd53007cf79dba/src/Discord.Net/Enums/GameType.cs#L5
[discord4j]: https://github.com/austinv11/Discord4J/blob/7bafbdbeca9d3a42d088303ce297e937c14b3f91/src/main/java/sx/blah/discord/api/internal/json/generic/StatusObject.java#L16
[dscord]: https://github.com/b1naryth1ef/dscord/blob/d0e3a42d2f4f1bdd417086854ec0745df04b7c22/src/dscord/types/user.d#L12