### PR TITLE
Fix API Methods

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -136,6 +136,11 @@ module Discordrb::API
   def widget_url(server_id, style = 'shield')
     "#{api_base}/guilds/#{server_id}/widget.png?style=#{style}"
   end
+  
+  # Make a splash URL from server and splash IDs
+  def splash_url(server_id, splash_id)
+    "https://cdn.discordapp.com/splashes/#{server_id}/#{splash_id}.jpg"
+  end
 
   # Make an emoji icon URL from emoji ID
   def emoji_icon_url(emoji_id)

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -136,7 +136,7 @@ module Discordrb::API
   def widget_url(server_id, style = 'shield')
     "#{api_base}/guilds/#{server_id}/widget.png?style=#{style}"
   end
-  
+
   # Make a splash URL from server and splash IDs
   def splash_url(server_id, splash_id)
     "https://cdn.discordapp.com/splashes/#{server_id}/#{splash_id}.jpg"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2271,7 +2271,7 @@ module Discordrb
 
     # @return [Array<Integration>] an array of all the integrations connected to this server.
     def integrations
-      integration = JSON.parse(API.server_integrations(@bot.token, @id))
+      integration = JSON.parse(API::Server.integrations(@bot.token, @id))
       integration.map { |element| Integration.new(element, @bot, self) }
     end
 
@@ -2279,7 +2279,7 @@ module Discordrb
     # @note For internal use only
     # @!visibility private
     def cache_embed
-      @embed = JSON.parse(API.server(@bot.token, @id))['embed_enabled'] if @embed.nil?
+      @embed = JSON.parse(API::Server.resolve(@bot.token, @id))['embed_enabled'] if @embed.nil?
     end
 
     # @return [true, false] whether or not the server has widget enabled
@@ -2333,7 +2333,7 @@ module Discordrb
 
     # @return [String] the hexadecimal ID used to identify this server's splash image for their VIP invite page.
     def splash_id
-      @splash_id = JSON.parse(API.server(@bot.token, @id))['splash'] if @splash_id.nil?
+      @splash_id = JSON.parse(API::Server.resolve(@bot.token, @id))['splash'] if @splash_id.nil?
       @splash_id
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2279,7 +2279,7 @@ module Discordrb
     # @note For internal use only
     # @!visibility private
     def cache_embed
-      @embed = JSON.parse(API::Server.resolve(@bot.token, @id))['embed_enabled'] if @embed.nil?
+      @embed ||= JSON.parse(API::Server.resolve(@bot.token, @id))['embed_enabled']
     end
 
     # @return [true, false] whether or not the server has widget enabled
@@ -2333,8 +2333,7 @@ module Discordrb
 
     # @return [String] the hexadecimal ID used to identify this server's splash image for their VIP invite page.
     def splash_id
-      @splash_id = JSON.parse(API::Server.resolve(@bot.token, @id))['splash'] if @splash_id.nil?
-      @splash_id
+      @splash_id ||= JSON.parse(API::Server.resolve(@bot.token, @id))['splash']
     end
 
     # @return [String, nil] the splash image URL for the server's VIP invite page.


### PR DESCRIPTION
Fixing the few remaining NoMethodErrors resulting from API methods that weren't updated back when all the API methods were split off into different modules. Also re-added `API#splash_url` since that got removed somehow.

Coding is weird, mang.