### PR TITLE
Fix filtering of playing events by game or type

### DIFF
--- a/lib/discordrb/events/presence.rb
+++ b/lib/discordrb/events/presence.rb
@@ -96,18 +96,10 @@ module Discordrb::Events
                end
         end,
         matches_all(@attributes[:game], event.game) do |a, e|
-          a == if a.is_a? String
-                 e.name
-               else
-                 e
-               end
+          a == e
         end,
         matches_all(@attributes[:type], event.type) do |a, e|
-          a == if a.is_a? Integer
-                 e.type
-               else
-                 e
-               end
+          a == e
         end
       ].reduce(true, &:&)
     end


### PR DESCRIPTION
There are two small issues in the PlayingEventHandler that result in crashes if a filter for game or type is used.

During the initialisation of PlayingEvent the game _object_ received from the server is flattened to its only attribute `name` (presence.rb:75). In line 100 `event.game.name` is accessed, but at this point `event.game` is only a string.

For filtering by event type the `type` attribute is accessed twice (i.e. `event.type.type`) in lines 105 and 107.