### PR TITLE
only perform custom emoji related checks on an ascii-only reaction

### DIFF
--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -48,7 +48,11 @@ module Discordrb::Events
           if a.is_a? Integer
             e.id == a
           elsif a.is_a? String
-            e.name == a || e.name == a.delete(':') || e.id == a.resolve_id
+            if e.name.ascii_only?
+              e.name == a || e.name == a.delete(':') || e.id == a.resolve_id
+            else
+              e.name == a
+            end
           else
             e == a
           end


### PR DESCRIPTION
The following

`e.name == a || e.name == a.delete(':') || e.id == a.resolve_id`

will raise *every* reaction events set to raise on a unicode emoji regardless if its the matching emoji or not, because `e.id` and `a.resolve_id` is always `0` for unicode reactions.

Worth noting that unicode isn't legal in custom emoji (they get converted to underscores when you try to create them with a unicode name, like "パンツ")

This attempts to solve that by making a check to see if the emoji is only ascii first to skip custom emoji-related checks.

Tested working with the following bot:

```ruby
require 'discordrb'
require 'yaml'

CONFIG = YAML.load_file 'config.yaml'

bot = Discordrb::Commands::CommandBot.new(
  token: CONFIG['token'],
  client_id: CONFIG['client_id'],
  prefix: CONFIG['prefix']
)

# Would previously raise on EVERY unicode reaction regardless:
bot.reaction_add(emoji: "\u2B50") do |event|
  puts "you reacted with \u2B50"
end

# Make sure I didn't break custom emoji:
bot.reaction_add(emoji: 'y32') do |event|
  puts 'you reacted with a custom emoji y32'
end

bot.reaction_add(emoji: ':y32:') do |event|
  puts 'you reacted with a custom emoji :y32:'
end

bot.reaction_add(emoji: 247789477945278465) do |event|
  puts 'you reacted with a custom emoji y32 by ID'
end

bot.run
```

The one case I can't figure out seen here in Nekka's bot:

```ruby
RUBOCOP_EMOTE = 'rubocop%3A246708457460334592'.freeze
PASS_EMOTE = 'helYea%3A236243426662678528'.freeze
FAIL_EMOTE = 'helNa%3A239120424938504192'.freeze

# ...

bot.reaction_add(emoji: DELETE_EMOTE) do |event|
# ...
```
https://github.com/Daniel-Worrall/discocop/blob/master/discop.rb#L6-L8

I can't see how this ever worked on the current (clean) master, at least I could not reproduce it working on master with my own custom emoji.

If @Daniel-Worrall could update his bot to master and check, that'd be great