### PR TITLE
Accept nil values when initializing Emoji ID

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1995,7 +1995,7 @@ module Discordrb
 
       @name = data['name']
       @server = server
-      @id = data['id'].to_i
+      @id = data['id'].nil? ? nil : data['id'].to_i
 
       process_roles(data['roles']) if server
     end


### PR DESCRIPTION
This is an alternative solution to #305. (bugfix)

The approach here realizes that the event handler tries to create an Emoji from the event payload:

```ruby
  class ReactionEvent
    def initialize(data, bot)
      #..
      @emoji = Discordrb::Emoji.new(data['emoji'], bot, nil)
      #..
    end
  end
```
and in `data.rb`:
```ruby
# Server emoji
class Emoji
  def initialize(data, bot, server)
    #..
    @id = data['id'].to_i
    #..
  end
end
```
Because `REACTION_*` events supply `id: null` for unicode reactions, the ID of a unicode reaction is cast to zero (`nil.to_i #=> 0`)

`"emoji"=>{"name"=>"💀", "id"=>nil}`

Therefore in `Emoji`, this is incorrect because unicode reactions have no ID.

As consequence, this fixes `ReactionEvent` attribute matching on *any* unicode reaction without touching the handler code because

`e.name == a || e.name == a.delete(':') || e.id == a.resolve_id`

`e.id #=> nil` & `a.resolve_id #=> 0`