### PR TITLE
Make Permissions Great Again

### DIFF
--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -74,13 +74,43 @@ module Discordrb
       end
     end
 
+    # Return the corresponding bits for an array of permission flag symbols.
+    # This is a class method that can be used to calculate bits instead
+    # of instancing a new Permissions object.
+    # @example Get the bits for permissions that could allow/deny read messages, connect, and speak
+    #   Permissions.bits [:read_messages, :connect, :speak] #=> 3146752
+    # @param list [Array<Symbol>]
+    # @return [Integer] the computed permissions integer
+    def self.bits(list)
+      value = 0
+
+      Flags.each do |position, flag|
+        value += 2**position if list.include? flag
+      end
+
+      value
+    end
+
     # Create a new Permissions object either as a blank slate to add permissions to (for example for
     #   {Channel#define_overwrite}) or from existing bit data to read out.
-    # @param bits [Integer] The permission bits that should be set from the beginning.
+    # @example Create a permissions object that could allow/deny read messages, connect, and speak by setting flags
+    #   permission = Permissions.new
+    #   permission.can_read_messages = true
+    #   permission.can_connect = true
+    #   permission.can_speak = true
+    # @example Create a permissions object that could allow/deny read messages, connect, and speak by an array of symbols
+    #   Permissions.new [:read_messages, :connect, :speak]
+    # @param bits [Integer, Array<Symbol>] The permission bits that should be set from the beginning, or an array of permission flag symbols
     # @param writer [RoleWriter] The writer that should be used to update data when a permission is set.
     def initialize(bits = 0, writer = nil)
       @writer = writer
-      @bits = bits
+
+      @bits = if bits.is_a? Array
+                self.class.bits(bits)
+              else
+                bits
+              end
+
       init_vars
     end
   end

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -56,6 +56,7 @@ module Discordrb
     end
 
     alias_method :can_administrate=, :can_administrator=
+    alias_method :administrate, :administrator
 
     attr_reader :bits
 

--- a/spec/permissions_spec.rb
+++ b/spec/permissions_spec.rb
@@ -1,0 +1,76 @@
+require 'discordrb'
+
+module Discordrb
+  describe Permissions do
+    subject { Permissions.new }
+
+    describe Permissions::Flags do
+      it 'creates a setter for each flag' do
+        responds_to_methods = Permissions::Flags.map do |_, flag|
+          subject.respond_to?(:"can_#{flag}=")
+        end
+
+        expect(responds_to_methods.all?).to eq true
+      end
+
+      it 'calls #write on its writer' do
+        writer = double
+        expect(writer).to receive(:write)
+
+        Permissions.new(0, writer).can_read_messages = true
+      end
+    end
+
+    context 'with Flags stubbed' do
+      before do
+        stub_const('Discordrb::Permissions::Flags', 0 => :foo, 1 => :bar)
+      end
+
+      describe '#init_vars' do
+        it 'sets an attribute for each flag' do
+          expect(
+            [
+              subject.instance_variable_get('@foo'),
+              subject.instance_variable_get('@bar')
+            ]
+          ).to eq [false, false]
+        end
+      end
+
+      describe '.bits' do
+        it 'returns the correct packed bits from an array of symbols' do
+          expect(Permissions.bits(%i[foo bar])).to eq 3
+        end
+      end
+
+      describe '#bits=' do
+        it 'updates the cached value' do
+          allow(subject).to receive(:init_vars)
+          subject.bits = 1
+          expect(subject.bits).to eq(1)
+        end
+
+        it 'calls #init_vars' do
+          expect(subject).to receive(:init_vars)
+          subject.bits = 0
+        end
+      end
+
+      describe '#initialize' do
+        it 'initializes with 0 bits' do
+          expect(subject.bits).to eq 0
+        end
+
+        it 'can initialize with an array of symbols' do
+          instance = Permissions.new %i[foo bar]
+          expect(instance.bits).to eq 3
+        end
+
+        it 'calls #init_vars' do
+          expect_any_instance_of(Permissions).to receive(:init_vars)
+          subject
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
~~*(Sorry/not sorry for the tired meme title)*~~ **I'm sorry.**

**Dealing with `Permissions` sucks.** This gets rid of the "boilerplate" of flipping bits and makes it suck less.

## Task: Shipping a new channel with overwrites
(This example depends on #321)
### Before

```ruby
allow = Discordrb::Permissions.new
allow.can_mention_everyone = true
allow.can_send_tts_messages = true

deny = Discordrb::Permissions.new
deny.can_create_instant_invite = true

# (let's just say we already have a Server and a Role)
overwrite = Discordrb::Overwrite.new(role, allow: allow, deny: deny)
server.create_channel('meme channel', 0, permission_overwrites: [overwrite])
```

### After

```ruby
overwrite = Discordrb::Overwrite.new role, allow: [:mention_everyone, :send_tts], deny: [:create_instant_invite]
server.create_channel('meme channel', 0, permission_overwrites: [overwrite])
```

## Task: Interacting with the REST API

Previously you would have to do something similar (create a `Permissions` instance) just to get some bits to ship to the API. This PR exposes a helper if you just want the bits and makes the API easier to use directly.

### After

```ruby
Discordrb::API::Channel.edit_channel_permissions(
  bot.token, 
  225375815087554563, 
  120571255635181568, 
  Discordrb::Permissions.bits([:read_messages, :attach_files]), 
  Discordrb::Permissions.bits([:mention_everyone, :use_external_emoji]), 
  'member'
)
```

This of course has implications in other places in the library where permissions are required. Methods could take an array of symbols and use the new initializer case to make `Permissions`, or users can use `Permissions.bits` for anything that doesn't but will take bits anyway. 

---

Todo:

- [x] Specs! :heart: 
- [x] Add `:administrate` alias