### PR TITLE
Enhance/create role

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -212,16 +212,20 @@ module Discordrb::API::Server
     )
   end
 
-  # Create a role (parameters such as name and colour will have to be set by update_role afterwards)
+  # Create a role (parameters such as name and colour if not set can be set by update_role afterwards)
+  # Permissions are the Discord defaults; allowed: invite creation, reading/sending messages,
+  # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
+  # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id)
+  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/roles",
-      nil,
-      Authorization: token
+      { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions }.to_json,
+      Authorization: token,
+      content_type: :json
     )
   end
 

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -217,7 +217,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions)
+  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -217,7 +217,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
+  def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -217,7 +217,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
+  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 104_324_161)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,
@@ -234,7 +234,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#batch-modify-guild-role
-  def update_role(token, server_id, role_id, name, colour, hoist = false, mentionable = false, packed_permissions = 36_953_089)
+  def update_role(token, server_id, role_id, name, colour, hoist = false, mentionable = false, packed_permissions = 104_324_161)
     Discordrb::API.request(
       :guilds_sid_roles_rid,
       server_id,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -217,7 +217,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id, name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 104_324_161)
+  def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2476,20 +2476,17 @@ module Discordrb
       Channel.new(JSON.parse(response), @bot)
     end
 
-    # @overload create_role
-    #   Creates a role on this server which can then be modified. It will be initialized
-    #   with the regular role defaults the client uses, i. e. name is "new role",
-    #   permissions are the default, colour is the default etc.
-    # @overload create_role(name, colour, hoist, mentionable, packed_permissions)
-    #   Creates a role on this server which can then be modified. It will be initialized
-    #   with custom role attributes. All attributes must be specified.
+    # Creates a role on this server which can then be modified. It will be initialized
+    # with the regular role defaults the client uses unless specified, i. e. name is "new role",
+    # permissions are the default, colour is the default etc.
+    # @param name [String] Name of the role to create
+    # @param colour [ColourRGB] The roles colour
+    # @param hoist [true, false]
+    # @param mentionable [true, false]
+    # @param packed_permissions [Integer] The packed permissions to write.
     # @return [Role] the created role.
-    def create_role(name = nil, colour = nil, hoist = nil, mentionable = nil, packed_permissions = nil)
-      response = if [name, colour, hoist, mentionable, packed_permissions].all?(&:nil?)
-                   API::Server.create_role(@bot.token, @id)
-                 else
-                   API::Server.create_role(@bot.token, @id, name, colour, hoist, mentionable, packed_permissions)
-                 end
+    def create_role(name: 'new role', colour: 0, hoist: false, mentionable: false, packed_permissions: 104_324_161)
+      response = API::Server.create_role(@bot.token, @id, name, colour, hoist, mentionable, packed_permissions)
 
       role = Role.new(JSON.parse(response), @bot, self)
       @roles << role

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2476,12 +2476,13 @@ module Discordrb
       Channel.new(JSON.parse(response), @bot)
     end
 
-    # Creates a role on this server which can then be modified. It will be initialized (on Discord's side)
-    # with the regular role defaults the client uses, i. e. name is "new role", permissions are the default,
-    # colour is the default etc.
-    # If all arguments are provided it will create the role with custom name, colour, hoist, mentionable,
-    # and packed_permissions properties, if they are not all provided it will just create the role with
-    # default settings.
+    # @overload create_role
+    #   Creates a role on this server which can then be modified. It will be initialized
+    #   with the regular role defaults the client uses, i. e. name is "new role",
+    #   permissions are the default, colour is the default etc.
+    # @overload create_role(name, colour, hoist, mentionable, packed_permissions)
+    #   Creates a role on this server which can then be modified. It will be initialized
+    #   with custom role attributes. All attributes must be specified.
     # @return [Role] the created role.
     def create_role(name = nil, colour = nil, hoist = nil, mentionable = nil, packed_permissions = nil)
       response = if [name, colour, hoist, mentionable, packed_permissions].all?(&:nil?)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2480,8 +2480,8 @@ module Discordrb
     # with the regular role defaults the client uses, i. e. name is "new role", permissions are the default,
     # colour is the default etc.
     # @return [Role] the created role.
-    def create_role
-      response = API::Server.create_role(@bot.token, @id)
+    def create_role(name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
+      response = API::Server.create_role(@bot.token, @id, name, colour, hoist, mentionable, packed_permissions)
       role = Role.new(JSON.parse(response), @bot, self)
       @roles << role
       role

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2479,8 +2479,11 @@ module Discordrb
     # Creates a role on this server which can then be modified. It will be initialized (on Discord's side)
     # with the regular role defaults the client uses, i. e. name is "new role", permissions are the default,
     # colour is the default etc.
+    # If all arguments are provided it will create the role with custom name, colour, hoist, mentionable,
+    # and packed_permissions properties, if they are not all provided it will just create the role with
+    # default settings.
     # @return [Role] the created role.
-    def create_role(name, colour, hoist, mentionable, packed_permissions)
+    def create_role(name = nil, colour = nil, hoist = nil, mentionable = nil, packed_permissions = nil)
       response = if [name, colour, hoist, mentionable, packed_permissions].all?(&:nil?)
                    API::Server.create_role(@bot.token, @id)
                  else

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2480,8 +2480,13 @@ module Discordrb
     # with the regular role defaults the client uses, i. e. name is "new role", permissions are the default,
     # colour is the default etc.
     # @return [Role] the created role.
-    def create_role(name = 'new role', colour = 0, hoist = false, mentionable = false, packed_permissions = 36_953_089)
-      response = API::Server.create_role(@bot.token, @id, name, colour, hoist, mentionable, packed_permissions)
+    def create_role(name, colour, hoist, mentionable, packed_permissions)
+      response = if [name, colour, hoist, mentionable, packed_permissions].all?(&:nil?)
+                   API::Server.create_role(@bot.token, @id)
+                 else
+                   API::Server.create_role(@bot.token, @id, name, colour, hoist, mentionable, packed_permissions)
+                 end
+
       role = Role.new(JSON.parse(response), @bot, self)
       @roles << role
       role


### PR DESCRIPTION
#309 API::Server.create_role, missing name, permissions, color, hoist, mentionable parameters

Adds those missing parameters to the create_role method.  
If all parameters are sent it will create it with those set parameters, if not it will fallback to defaults.