### PR TITLE
Update MessageLength Error to reflect API change

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -78,7 +78,7 @@ module Discordrb::API::Channel
     )
   rescue RestClient::BadRequest => e
     parsed = JSON.parse(e.response.body)
-    raise Discordrb::Errors::MessageTooLong, "Message over the character limit (#{message.length} > 2000)" if parsed['content'] && parsed['content'].is_a?(Array) && parsed['content'].first == 'Must be 2000 or less characters long.'
+    raise Discordrb::Errors::MessageTooLong, "Message over the character limit (#{message.length} > 2000)" if parsed['content'] && parsed['content'].is_a?(Array) && parsed['content'].first == 'Must be 2000 or fewer characters long.'
     raise
   end
 


### PR DESCRIPTION
Using Postman, the current response on this kind of error gives
```
{
  "content": [
    "Must be 2000 or fewer characters long."
  ]
}
```