### PR TITLE
Fall back on /oauth2/applications/@me when client_id is nil

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -263,7 +263,6 @@ module Discordrb
     end
 
     # Creates an OAuth invite URL that can be used to invite this bot to a particular server.
-    # Requires the application ID to have been set during initialization.
     # @param server [Server, nil] The server the bot should be invited to, or nil if a general invite should be created.
     # @param permission_bits [Integer, String] Permission bits that should be appended to invite url.
     # @return [String] the OAuth invite URL.

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -201,8 +201,7 @@ module Discordrb
     # The bot's OAuth application.
     # @return [Application, nil] The bot's application info. Returns `nil` if bot is not a bot account.
     def bot_application
-      gateway_check
-      return nil unless @type == :bot
+      return unless @type == :bot
       response = API.oauth_application(token)
       Application.new(JSON.parse(response), self)
     end

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -268,7 +268,7 @@ module Discordrb
     # @param permission_bits [Integer, String] Permission bits that should be appended to invite url.
     # @return [String] the OAuth invite URL.
     def invite_url(server: nil, permission_bits: nil)
-      raise 'No application ID has been set during initialization! Add one as the `client_id` named parameter while creating your bot.' unless @client_id
+      @client_id ||= bot_application.id
 
       server_id_str = server ? "&guild_id=#{server.id}" : ''
       permission_bits_str = permission_bits ? "&permissions=#{permission_bits}" : ''


### PR DESCRIPTION
After this PR, `client_id` can always be omitted from the bot initializer and all methods should work. May be worth noting in the next changelog.

#333 