### PR TITLE
[WIP] Add optional error checking to Webhooks::Embeds

### DIFF
--- a/lib/discordrb/webhooks.rb
+++ b/lib/discordrb/webhooks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'discordrb/webhooks/version'
+require 'discordrb/webhooks/errors'
 require 'discordrb/webhooks/embeds'
 require 'discordrb/webhooks/client'
 require 'discordrb/webhooks/builder'

--- a/lib/discordrb/webhooks/errors.rb
+++ b/lib/discordrb/webhooks/errors.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Discordrb::Webhooks
+  # Custom webhook and embed related errors
+  module Errors
+    # Raised when an Embed doesn't meet certain formatting criteria
+    class EmbedFormatError < RuntimeError; end
+   
+    # Raised when a Client tries to execute a webhook with too many embed objects attached
+    class TooManyEmbeds < RuntimeError
+      # Default message for this exception
+      def message
+        'Webhook messages can only contain up to 5 embed objects.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
We get a lot of questions about Embeds because people are getting `400 Bad Request`. We could make a wiki page, add examples, but I think it should be easy enough to have the library tell them what they are doing wrong, and stop the request before it gets sent to Discord. (this extends to users of `discordrb-webhooks` too)

The limitations of embeds aren't documented, as I'm certain they could change at any time - so I've made this checking optional under a `check_format` named argument that defaults to `true`, so it can be turned off in case it ever becomes inaccurate / before discordrb contributor can update the limits.

Just wanted to open this PR to get any early feedback. This still has debug code and memes inside of it.

I need to:
- [ ] Test that each of these limits are accurate as documented by the community
- [ ] Figure out why the `require 'discordrb/webhooks/errors'` fails (??) and actually use my exception class
- [ ] See that there aren't any other additional limits I missed (comments welcome!)
- [ ] This primarily handles Embeds, but can extend to Webhooks too. That said, the only similar limitation I know of is that Webhook posts can have only up to 5 embeds. I've not implemented this exception yet.
- [ ] Remove memes
- [ ] Document `check_format`
- [ ] Pass rubocop, as I know its going to fail when I hit "Create pull request"

I've opted to just use one exception (`EmbedFormatError`) and build a string of all the errors found in the embed, and then only `raise` once. This is opposed to making a `raise` for each property, where you would have to keep retrying to lint more errors in the embed... this way you can hopefully fix them all in one go. Perhaps this isn't appropriate though? I'm not sure.

This also uses safe navigation.

Examples:
![](https://images.discordapp.net/.eJwNyFEOgyAMANC7cADKZB3V2xAkaKYtoTX7WHb3-T7f113jcIvbzLouAOuuRcbq1WTkVn0TaUfNfVdf5IRslst2VjYFihM9aLohxkAUIIaE6RVxTjhHCs-7Ln6zfNh3bu73B-dPIrA.26yb_Ylf2SvQHqW4xUVw8ws1zro)

![](https://images.discordapp.net/.eJwNwVEOgyAMANC7cACKIFC8DUGCZtoSqNnHsrtv733UMy61qUOkzw1gP2fhsespPHKrujG3q-Z-Tl34hiySy3FXkgnoLC5o_7x3BtGAM9HHEINNya_rEmKCh17Eb9Kdmvr-AOfNIrg.WutoZr_4Hy5XQ-eTTWTPnE-ssfg)