### PR TITLE
add support for ffmpeg options

### DIFF
--- a/lib/discordrb/voice/encoder.rb
+++ b/lib/discordrb/voice/encoder.rb
@@ -75,7 +75,7 @@ module Discordrb::Voice
     # @param file [String] The path or URL to encode.
     # @param options [String] ffmpeg options to pass after the -i flag
     # @return [IO] the audio, encoded as s16le PCM
-    def encode_file(file, options="")
+    def encode_file(file, options = '')
       command = "#{ffmpeg_command} -loglevel 0 -i \"#{file}\" #{options} -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
       IO.popen(command)
     end
@@ -85,7 +85,7 @@ module Discordrb::Voice
     # @param io [IO] The stream to encode.
     # @param options [String] ffmpeg options to pass after the -i flag
     # @return [IO] the audio, encoded as s16le PCM
-    def encode_io(io, options="")
+    def encode_io(io, options = '')
       ret_io, writer = IO.pipe
       command = "#{ffmpeg_command} -loglevel 0 -i - #{options} -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
       spawn(command, in: io, out: writer)

--- a/lib/discordrb/voice/encoder.rb
+++ b/lib/discordrb/voice/encoder.rb
@@ -73,19 +73,21 @@ module Discordrb::Voice
     # an audio track. For a list of supported formats, see https://ffmpeg.org/general.html#Audio-Codecs. It even accepts
     # URLs, though encoding them is pretty slow - I recommend to make a stream of it and then use {#encode_io} instead.
     # @param file [String] The path or URL to encode.
+    # @param options [String] ffmpeg options to pass after the -i flag
     # @return [IO] the audio, encoded as s16le PCM
-    def encode_file(file)
-      command = "#{ffmpeg_command} -loglevel 0 -i \"#{file}\" -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
+    def encode_file(file, options="")
+      command = "#{ffmpeg_command} -loglevel 0 -i \"#{file}\" #{options} -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
       IO.popen(command)
     end
 
     # Encodes an arbitrary IO audio stream using ffmpeg. Accepts pretty much any media format, even videos with audio
     # tracks. For a list of supported audio formats, see https://ffmpeg.org/general.html#Audio-Codecs.
     # @param io [IO] The stream to encode.
+    # @param options [String] ffmpeg options to pass after the -i flag
     # @return [IO] the audio, encoded as s16le PCM
-    def encode_io(io)
+    def encode_io(io, options="")
       ret_io, writer = IO.pipe
-      command = "#{ffmpeg_command} -loglevel 0 -i - -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
+      command = "#{ffmpeg_command} -loglevel 0 -i - #{options} -f s16le -ar 48000 -ac 2 #{filter_volume_argument} pipe:1"
       spawn(command, in: io, out: writer)
       ret_io
     end

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -233,15 +233,15 @@ module Discordrb::Voice
     # Plays an encoded audio file of arbitrary format to the channel.
     # @see Encoder#encode_file
     # @see #play
-    def play_file(file)
-      play @encoder.encode_file(file)
+    def play_file(file, options="")
+      play @encoder.encode_file(file, options)
     end
 
     # Plays a stream of encoded audio data of arbitrary format to the channel.
     # @see Encoder#encode_io
     # @see #play
-    def play_io(io)
-      play @encoder.encode_io(io)
+    def play_io(io, options="")
+      play @encoder.encode_io(io, options)
     end
 
     # Plays a stream of audio data in the DCA format. This format has the advantage that no recoding has to be

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -233,14 +233,14 @@ module Discordrb::Voice
     # Plays an encoded audio file of arbitrary format to the channel.
     # @see Encoder#encode_file
     # @see #play
-    def play_file(file, options="")
+    def play_file(file, options = '')
       play @encoder.encode_file(file, options)
     end
 
     # Plays a stream of encoded audio data of arbitrary format to the channel.
     # @see Encoder#encode_io
     # @see #play
-    def play_io(io, options="")
+    def play_io(io, options = '')
       play @encoder.encode_io(io, options)
     end
 


### PR DESCRIPTION
add the options parameter to play_file and play_io, allowing options to be passed to ffmpeg (after the -i flag)

The same functionality exists in discord.py and I found it to be pretty useful for playing certain segments of a given audio file or adding audio filters.