### PR TITLE
Fix Message#my_reactions, add Reaction#to_s

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1978,7 +1978,7 @@ module Discordrb
     # Returns the reactions made by the current bot or user
     # @return [Array<Reaction>] the reactions
     def my_reactions
-      @reactions.select(&:me)
+      @reactions.values.select(&:me)
     end
 
     # Reacts to a message

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2047,6 +2047,13 @@ module Discordrb
       @id = data['emoji']['id'].nil? ? nil : data['emoji']['id'].to_i
       @name = data['emoji']['name']
     end
+
+    # Converts this Reaction into a string that can be sent back to Discord in other reaction endpoints.
+    # If ID is present, it will be rendered into the form of `name:id`.
+    # @return [String] the name of this reaction, including the ID if it is a custom emoji
+    def to_s
+      id.nil? ? name : "#{name}:#{id}"
+    end
   end
 
   # Server emoji


### PR DESCRIPTION
`Message#my_reactions` was broken after one of my two reactions PRs changed how reactions were stored inside a message from an Array to a Hash.

This also adds `Reaction#to_s`, which will convert a reaction into a string that can be sent back to the API, which is useful on doing work on messages with existing reactions, where before [this was pretty ugly to do](https://github.com/mattantonelli/usalia-bot/blob/master/lib/usalia_bot/events/poll.rb#L25):

```ruby
message #=> Message
reactions = message.my_reactions #=> Array<Reaction>

# Delete all of the bot's reactions on this message
reactions.each { |r| message.delete_own_reaction r.to_s }
```