### PR TITLE
Ignore .gem Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /tmp/
 /.idea/
 .DS_Store
+*.gem


### PR DESCRIPTION
There's no reason why .gem shouldn't be ignored, it jsut amkes the flow a lot easier (and prevent accidental commiting of .gem files)