### PR TITLE
Add missing embed attributes

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1611,14 +1611,33 @@ module Discordrb
     #   * `:image`
     attr_reader :type
 
-    # @return [EmbedProvider, nil] the provider of the embed object. `nil` is there is not a provider
+    # @return [Time, nil] the timestamp of the embed object. `nil` if there is not a timestamp
+    attr_reader :timestamp
+
+    # @return [String, nil] the color of the embed object. `nil` if there is not a color
+    attr_reader :color
+    alias_method :colour, :color
+
+    # @return [EmbedFooter, nil] the footer of the embed object. `nil` if there is not a footer
+    attr_reader :footer
+
+    # @return [EmbedProvider, nil] the provider of the embed object. `nil` if there is not a provider
     attr_reader :provider
 
-    # @return [EmbedThumbnail, nil] the thumbnail of the embed object. `nil` is there is not a thumbnail
+    # @return [EmbedImage, nil] the image of the embed object. `nil` if there is not an image
+    attr_reader :image
+
+    # @return [EmbedThumbnail, nil] the thumbnail of the embed object. `nil` if there is not a thumbnail
     attr_reader :thumbnail
 
-    # @return [EmbedAuthor, nil] the author of the embed object. `nil` is there is not an author
+    # @return [EmbedVideo, nil] the video of the embed object. `nil` if there is not a video
+    attr_reader :video
+
+    # @return [EmbedAuthor, nil] the author of the embed object. `nil` if there is not an author
     attr_reader :author
+
+    # @return [Array<EmbedField>, nil] the fields of the embed object. `nil` if there are no fields
+    attr_reader :fields
 
     # @!visibility private
     def initialize(data, message)
@@ -1628,9 +1647,91 @@ module Discordrb
       @title = data['title']
       @type = data['type'].to_sym
       @description = data['description']
+      @timestamp = data['timestamp'].nil? ? nil : Time.parse(data['timestamp'])
+      @color = data['color']
+      @footer = data['footer'].nil? ? nil : EmbedFooter.new(data['footer'], self)
+      @image = data['image'].nil? ? nil : EmbedImage.new(data['image'], self)
+      @video = data['video'].nil? ? nil : EmbedVideo.new(data['video'], self)
       @provider = data['provider'].nil? ? nil : EmbedProvider.new(data['provider'], self)
       @thumbnail = data['thumbnail'].nil? ? nil : EmbedThumbnail.new(data['thumbnail'], self)
       @author = data['author'].nil? ? nil : EmbedAuthor.new(data['author'], self)
+      @fields = data['fields'].nil? ? nil : data['fields'].map { |field| EmbedField.new(field, self) }
+    end
+  end
+
+  # An Embed footer for the embed object
+  class EmbedFooter
+    # @return [Embed] the embed object this is based on.
+    attr_reader :embed
+
+    # @return [String] the footer text.
+    attr_reader :text
+
+    # @return [String] the URL of the footer icon.
+    attr_reader :icon_url
+
+    # @return [String] the proxied URL of the footer icon.
+    attr_reader :proxy_icon_url
+
+    # @!visibility private
+    def initialize(data, embed)
+      @embed = embed
+
+      @text = data['text']
+      @icon_url = data['icon_url']
+      @proxy_icon_url = data['proxy_icon_url']
+    end
+  end
+
+  # An Embed image for the embed object
+  class EmbedImage
+    # @return [Embed] the embed object this is based on.
+    attr_reader :embed
+
+    # @return [String] the source URL of the image.
+    attr_reader :url
+
+    # @return [String] the proxy URL of the image.
+    attr_reader :proxy_url
+
+    # @return [Integer] the width of the image, in pixels.
+    attr_reader :width
+
+    # @return [Integer] the height of the image, in pixels.
+    attr_reader :height
+
+    # @!visibility private
+    def initialize(data, embed)
+      @embed = embed
+
+      @url = data['url']
+      @proxy_url = data['proxy_url']
+      @width = data['width']
+      @height = data['height']
+    end
+  end
+
+  # An Embed video for the embed object
+  class EmbedVideo
+    # @return [Embed] the embed object this is based on.
+    attr_reader :embed
+
+    # @return [String] the source URL of the video.
+    attr_reader :url
+
+    # @return [Integer] the width of the video, in pixels.
+    attr_reader :width
+
+    # @return [Integer] the height of the video, in pixels.
+    attr_reader :height
+
+    # @!visibility private
+    def initialize(data, embed)
+      @embed = embed
+
+      @url = data['url']
+      @width = data['width']
+      @height = data['height']
     end
   end
 
@@ -1700,6 +1801,30 @@ module Discordrb
 
       @name = data['name']
       @url = data['url']
+    end
+  end
+
+  # An Embed field for the embed object
+  class EmbedField
+    # @return [Embed] the embed object this is based on.
+    attr_reader :embed
+
+    # @return [String] the field's name.
+    attr_reader :name
+
+    # @return [String] the field's value.
+    attr_reader :value
+
+    # @return [true, false] whether this field is inline.
+    attr_reader :inline
+
+    # @!visibility private
+    def initialize(data, embed)
+      @embed = embed
+
+      @name = data['name']
+      @value = data['value']
+      @inline = data['inline']
     end
   end
 


### PR DESCRIPTION
Adds attributes that are currently missing from [Embed](https://discordapp.com/developers/docs/resources/channel#embed-object).

Includes the following basic attributes:
* `timestamp`
* `color`

and the following complex attributes, for which new objects are created:
* `footer`
* `image`
* `video`
* `fields`

Also fixes minor typos in the existing Embed attribute documentation.