### PR TITLE
Add #hash and #eql? to IDObject

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -71,11 +71,14 @@ module Discordrb
     # @return [Integer] the ID which uniquely identifies this object across Discord.
     attr_reader :id
     alias_method :resolve_id, :id
+    alias_method :hash, :id
 
     # ID based comparison
     def ==(other)
       Discordrb.id_compare(@id, other)
     end
+
+    alias_method :eql?, :==
 
     # Estimates the time this object was generated on based on the beginning of the ID. This is fairly accurate but
     # shouldn't be relied on as Discord might change its algorithm at any time


### PR DESCRIPTION
Methods like [Array#&](https://ruby-doc.org/core-2.4.0/Array.html#method-i-26) use an object's `hash` and `eql?` methods for comparisons. This PR adds these methods to allow for proper comparisons and set operations on objects that implement the [IDObject](http://www.rubydoc.info/gems/discordrb/Discordrb/IDObject) mixin.

**Before:**

```ruby
>> [user] & [user]
=> []
```

**After:**

```ruby
>> [user] & [user]
=> [user]
```