### PR TITLE
Reaction Events Parsing on Self

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1009,10 +1009,14 @@ module Discordrb
       when :MESSAGE_REACTION_ADD
         add_message_reaction(data)
 
+        return if self.profile.id == data['user_id'].to_i && !should_parse_self
+
         event = ReactionAddEvent.new(data, self)
         raise_event(event)
       when :MESSAGE_REACTION_REMOVE
         remove_message_reaction(data)
+
+        return if self.profile.id == data['user_id'].to_i && !should_parse_self
 
         event = ReactionRemoveEvent.new(data, self)
         raise_event(event)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1009,14 +1009,14 @@ module Discordrb
       when :MESSAGE_REACTION_ADD
         add_message_reaction(data)
 
-        return if self.profile.id == data['user_id'].to_i && !should_parse_self
+        return if profile.id == data['user_id'].to_i && !should_parse_self
 
         event = ReactionAddEvent.new(data, self)
         raise_event(event)
       when :MESSAGE_REACTION_REMOVE
         remove_message_reaction(data)
 
-        return if self.profile.id == data['user_id'].to_i && !should_parse_self
+        return if profile.id == data['user_id'].to_i && !should_parse_self
 
         event = ReactionRemoveEvent.new(data, self)
         raise_event(event)


### PR DESCRIPTION
- [ ] Specs

This prevents the events from firing when the bot is set to not parse self.

Let me know if this should be added to any other events.