### PR TITLE
Fix role priority in defined_role_permission?

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -383,7 +383,7 @@ module Discordrb
     private
 
     def defined_role_permission?(action, channel)
-      roles_to_check = @roles + [@server.everyone_role]
+      roles_to_check = [@server.everyone_role] + @roles
 
       # For each role, check if
       #   (1) the channel explicitly allows or permits an action for the role and


### PR DESCRIPTION
Role permissions take precedence over `@everyone` permissions, so they should be checked last.

In the screenshot below, we have a channel that denies **Read Messages** to `@everyone` but allows **Read Messages** to the `Bot` role. Role permissions take precedence, so users with the `Bot` role are allowed to read messages in the channel.

![image](https://cloud.githubusercontent.com/assets/1176304/26685608/999e2e84-46b8-11e7-8752-81a4da409945.png)

We would expect `#defined_role_permission?(:read_messages, CHANNEL)` for a user with the `Bot` role to return `true`, but it currently returns `false`. This is because the last role checked for permissions is `@everyone` which denies **Read Messages**. By checking `@everyone` first, the precedence issue is resolved.