### PR TITLE
Add :rescue command attribute for lazy exception handling

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -126,7 +126,10 @@ module Discordrb::Commands
         quote_start: attributes[:quote_start] || '"',
 
         # Quoted mode ending character
-        quote_end: attributes[:quote_end] || attributes[:quote_start] || '"'
+        quote_end: attributes[:quote_end] || attributes[:quote_start] || '"',
+
+        # Default block for handling internal exceptions, or a string to respond with
+        rescue: attributes[:rescue]
       }
 
       @permissions = {

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -44,6 +44,9 @@ module Discordrb::Commands
     #   command will be available again.
     # @option attributes [Symbol] :bucket The rate limit bucket that should be used for rate limiting. No rate limiting
     #   will be done if unspecified or nil.
+    # @option attributes [String, #call] :rescue A string to respond with, or a block to be called in the event an exception
+    #   is raised internally. If given a String, `%exception%` will be substituted with the exception's `#message`. If given
+    #   a `Proc`, it will be passed the `CommandEvent` along with the `Exception`.
     # @yield The block is executed when the command is executed.
     # @yieldparam event [CommandEvent] The event of the message that contained the command.
     # @note `LocalJumpError`s are rescued from internally, giving bots the opportunity to use `return` or `break` in
@@ -51,6 +54,7 @@ module Discordrb::Commands
     # @return [Command] The command that was added.
     def command(name, attributes = {}, &block)
       @commands ||= {}
+      attributes[:rescue] ||= @attributes[:rescue]
       if name.is_a? Array
         new_command = nil
 


### PR DESCRIPTION
It is useful to perform follow up actions when unexpected errors occur internally. This adds a command attribute that will be `#called` whenever something unhandled by the command's `@block` is raised, or alternatively a String to respond to the `event` with.

Example:
```ruby
bot.command(:test, rescue: "oops! %exception%") { 1 / 0 }
```
![image](https://user-images.githubusercontent.com/6119032/26843963-efc25744-4abf-11e7-903f-6d1afe477b06.png)

With a custom proc:
```ruby
rescue_proc = proc do |event, exception|
  BOT.user(120571255635181568).pm(
    "#{event.user.mention} broke your stuff: #{exception}"
  )
end

bot.command(:test, rescue: rescue_proc) { 1 / 0 }
```