### PR TITLE
Add id & name matching for Webhook events

### DIFF
--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -387,8 +387,9 @@ module Discordrb
 
     # This **event** is raised when a webhook is updated.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [String, Integer, Server] :server Matches the server.
-    # @option attributes [String, Integer, Channel] :channel Matches the channel.
+    # @option attributes [String, Integer, Server] :server Matches the server by name, id or instance.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel by name, id or instance.
+    # @option attribute [String, Integer, Webhook] :webhook Matches the webhook by name, id or instance.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [WebhookUpdateEvent] The event that was raised.
     # @return [WebhookUpdateEventHandler] the event handler that was registered.

--- a/lib/discordrb/events/webhooks.rb
+++ b/lib/discordrb/events/webhooks.rb
@@ -45,6 +45,15 @@ module Discordrb::Events
           else
             a == e
           end
+        end,
+        matches_all(@attributes[:webhook], event) do |a, e|
+          a == if a.is_a? String
+                 e.name
+               elsif a.is_a? Integer
+                 e.id
+               else
+                 e
+               end
         end
       ].reduce(true, &:&)
     end


### PR DESCRIPTION
Something that was meant to go in the previous Webhook PR but got merged before I had access to my dev tools to fix. Damn motherboard crashing.