### PR TITLE
Doc fix for TypingEvent

### DIFF
--- a/lib/discordrb/events/typing.rb
+++ b/lib/discordrb/events/typing.rb
@@ -10,7 +10,7 @@ module Discordrb::Events
     # @return [Channel] the channel on which a user started typing.
     attr_reader :channel
 
-    # @return [Member] the user that started typing.
+    # @return [User, Member, Recipient] the user that started typing.
     attr_reader :user
     alias_method :member, :user
 


### PR DESCRIPTION
Looking at the code the `user` attribute can be any one of those 3.