### PR TITLE
Fix Server#delete_role, Channel#delete_message

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -16,7 +16,7 @@ module Discordrb::API::Channel
 
   # Update a channel's data
   # https://discordapp.com/developers/docs/resources/channel#modify-channel
-  def update(token, channel_id, name, topic, position, bitrate, user_limit, reason)
+  def update(token, channel_id, name, topic, position, bitrate, user_limit, reason = nil)
     Discordrb::API.request(
       :channels_cid,
       channel_id,
@@ -31,7 +31,7 @@ module Discordrb::API::Channel
 
   # Delete a channel
   # https://discordapp.com/developers/docs/resources/channel#deleteclose-channel
-  def delete(token, channel_id, reason)
+  def delete(token, channel_id, reason = nil)
     Discordrb::API.request(
       :channels_cid,
       channel_id,
@@ -205,7 +205,7 @@ module Discordrb::API::Channel
 
   # Update a channels permission for a role or member
   # https://discordapp.com/developers/docs/resources/channel#edit-channel-permissions
-  def update_permission(token, channel_id, overwrite_id, allow, deny, type, reason)
+  def update_permission(token, channel_id, overwrite_id, allow, deny, type, reason = nil)
     Discordrb::API.request(
       :channels_cid_permissions_oid,
       channel_id,
@@ -247,7 +247,7 @@ module Discordrb::API::Channel
 
   # Delete channel permission
   # https://discordapp.com/developers/docs/resources/channel#delete-channel-permission
-  def delete_permission(token, channel_id, overwrite_id, reason)
+  def delete_permission(token, channel_id, overwrite_id, reason = nil)
     Discordrb::API.request(
       :channels_cid_permissions_oid,
       channel_id,

--- a/lib/discordrb/api/invite.rb
+++ b/lib/discordrb/api/invite.rb
@@ -16,7 +16,7 @@ module Discordrb::API::Invite
 
   # Delete an invite by code
   # https://discordapp.com/developers/docs/resources/invite#delete-invite
-  def delete(token, code, reason)
+  def delete(token, code, reason = nil)
     Discordrb::API.request(
       :invites_code,
       nil,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -30,7 +30,7 @@ module Discordrb::API::Server
 
   # Update a server
   # https://discordapp.com/developers/docs/resources/guild#modify-guild
-  def update(token, server_id, name, region, icon, afk_channel_id, afk_timeout, reason)
+  def update(token, server_id, name, region, icon, afk_channel_id, afk_timeout, reason = nil)
     Discordrb::API.request(
       :guilds_sid,
       server_id,
@@ -44,7 +44,7 @@ module Discordrb::API::Server
   end
 
   # Transfer server ownership
-  def transfer_ownership(token, server_id, user_id, reason)
+  def transfer_ownership(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid,
       server_id,
@@ -83,7 +83,7 @@ module Discordrb::API::Server
 
   # Create a channel
   # https://discordapp.com/developers/docs/resources/guild#create-guild-channel
-  def create_channel(token, server_id, name, type, bitrate, user_limit, permission_overwrites, reason)
+  def create_channel(token, server_id, name, type, bitrate, user_limit, permission_overwrites, reason = nil)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
@@ -98,7 +98,7 @@ module Discordrb::API::Server
 
   # Update a channels position
   # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel
-  def update_channel(token, server_id, channel_id, position, reason)
+  def update_channel(token, server_id, channel_id, position, reason = nil)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
@@ -157,7 +157,7 @@ module Discordrb::API::Server
 
   # Remove user from server
   # https://discordapp.com/developers/docs/resources/guild#remove-guild-member
-  def remove_member(token, server_id, user_id, reason)
+  def remove_member(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid,
       server_id,
@@ -183,7 +183,7 @@ module Discordrb::API::Server
 
   # Ban a user from a server and delete their messages from the last message_days days
   # https://discordapp.com/developers/docs/resources/guild#create-guild-ban
-  def ban_user(token, server_id, user_id, message_days, reason)
+  def ban_user(token, server_id, user_id, message_days, reason = nil)
     Discordrb::API.request(
       :guilds_sid_bans_uid,
       server_id,
@@ -197,7 +197,7 @@ module Discordrb::API::Server
 
   # Unban a user from a server
   # https://discordapp.com/developers/docs/resources/guild#remove-guild-ban
-  def unban_user(token, server_id, user_id, reason)
+  def unban_user(token, server_id, user_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_bans_uid,
       server_id,
@@ -225,7 +225,7 @@ module Discordrb::API::Server
   # sending TTS messages, embedding links, sending files, reading the history, mentioning everybody,
   # connecting to voice, speaking and voice activity (push-to-talk isn't mandatory)
   # https://discordapp.com/developers/docs/resources/guild#get-guild-roles
-  def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions, reason)
+  def create_role(token, server_id, name, colour, hoist, mentionable, packed_permissions, reason = nil)
     Discordrb::API.request(
       :guilds_sid_roles,
       server_id,
@@ -258,7 +258,7 @@ module Discordrb::API::Server
 
   # Delete a role
   # https://discordapp.com/developers/docs/resources/guild#delete-guild-role
-  def delete_role(token, server_id, role_id, reason)
+  def delete_role(token, server_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_roles_rid,
       server_id,
@@ -271,7 +271,7 @@ module Discordrb::API::Server
 
   # Adds a single role to a member
   # https://discordapp.com/developers/docs/resources/guild#add-guild-member-role
-  def add_member_role(token, server_id, user_id, role_id, reason)
+  def add_member_role(token, server_id, user_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid_roles_rid,
       server_id,
@@ -285,7 +285,7 @@ module Discordrb::API::Server
 
   # Removes a single role from a member
   # https://discordapp.com/developers/docs/resources/guild#remove-guild-member-role
-  def remove_member_role(token, server_id, user_id, role_id, reason)
+  def remove_member_role(token, server_id, user_id, role_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_uid_roles_rid,
       server_id,
@@ -310,7 +310,7 @@ module Discordrb::API::Server
 
   # Begin server prune
   # https://discordapp.com/developers/docs/resources/guild#begin-guild-prune
-  def begin_prune(token, server_id, days, reason)
+  def begin_prune(token, server_id, days, reason = nil)
     Discordrb::API.request(
       :guilds_sid_prune,
       server_id,
@@ -399,7 +399,7 @@ module Discordrb::API::Server
   end
 
   # Adds a custom emoji
-  def add_emoji(token, server_id, image, name, reason)
+  def add_emoji(token, server_id, image, name, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis,
       server_id,
@@ -413,7 +413,7 @@ module Discordrb::API::Server
   end
 
   # Changes an emoji name
-  def edit_emoji(token, server_id, emoji_id, name, reason)
+  def edit_emoji(token, server_id, emoji_id, name, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,
       server_id,
@@ -427,7 +427,7 @@ module Discordrb::API::Server
   end
 
   # Deletes a custom emoji
-  def delete_emoji(token, server_id, emoji_id, reason)
+  def delete_emoji(token, server_id, emoji_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,
       server_id,

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -27,7 +27,7 @@ module Discordrb::API::User
   end
 
   # Change the current bot's nickname on a server
-  def change_own_nickname(token, server_id, nick, reason)
+  def change_own_nickname(token, server_id, nick, reason = nil)
     Discordrb::API.request(
       :guilds_sid_members_me_nick,
       server_id, # This is technically a guild endpoint

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -27,7 +27,7 @@ module Discordrb::API::Webhook
 
   # Update a webhook
   # https://discordapp.com/developers/docs/resources/webhook#modify-webhook
-  def update_webhook(token, webhook_id, data, reason)
+  def update_webhook(token, webhook_id, data, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
       webhook_id,
@@ -42,7 +42,7 @@ module Discordrb::API::Webhook
 
   # Update a webhook via webhook token
   # https://discordapp.com/developers/docs/resources/webhook#modify-webhook-with-token
-  def token_update_webhook(webhook_token, webhook_id, data, reason)
+  def token_update_webhook(webhook_token, webhook_id, data, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
       webhook_id,
@@ -56,7 +56,7 @@ module Discordrb::API::Webhook
 
   # Deletes a webhook
   # https://discordapp.com/developers/docs/resources/webhook#delete-webhook
-  def delete_webhook(token, webhook_id, reason)
+  def delete_webhook(token, webhook_id, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
       webhook_id,
@@ -69,7 +69,7 @@ module Discordrb::API::Webhook
 
   # Deletes a webhook via webhook token
   # https://discordapp.com/developers/docs/resources/webhook#delete-webhook-with-token
-  def token_delete_webhook(webhook_token, webhook_id, reason)
+  def token_delete_webhook(webhook_token, webhook_id, reason = nil)
     Discordrb::API.request(
       :webhooks_wid,
       webhook_id,

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1008,8 +1008,9 @@ module Discordrb
     end
 
     # Deletes this role. This cannot be undone without recreating the role!
-    def delete
-      API::Server.delete_role(@bot.token, @server.id, @id)
+    # @param reason [String] the reason for this role's deletion
+    def delete(reason = nil)
+      API::Server.delete_role(@bot.token, @server.id, @id, reason)
       @server.delete_role(@id)
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1419,9 +1419,8 @@ module Discordrb
 
     # Deletes a message on this channel. Mostly useful in case a message needs to be deleted when only the ID is known
     # @param message [Message, String, Integer, #resolve_id] The message that should be deleted.
-    # @param reason [String] The reason the for the message deletion.
-    def delete_message(message, reason = nil)
-      API::Channel.delete_message(@bot.token, @id, message.resolve_id, reason)
+    def delete_message(message)
+      API::Channel.delete_message(@bot.token, @id, message.resolve_id)
     end
 
     # Permanently deletes this channel


### PR DESCRIPTION
- `Server#delete role` was broken because the API method always expected a `reason` argument.
- Made all API methods that take a reason consistently nilable / optional so that adding reasons in the next release isn't a breaking change
- ~~Because `X-Audit-Log-Reason` is always handed off to `API.request` even if its value is `nil` (since it's an optional argument, this *actually* creates an unsightly entry in the audit log (see screencap). I've added a piece of logic to reject this header if it has a `nil` value so that this doesn't happen.~~
- `Channel#delete_message` was broken because its API method does not accept a `reason` argument, as it isn't auditable with a reason.
![image](https://user-images.githubusercontent.com/6119032/27787971-bd208b76-5fb4-11e7-94ca-8638c269efcb.png)
