### PR TITLE
Fix #avatar_url for nil avatars

### DIFF
--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -129,6 +129,12 @@ module Discordrb::API::User
     )
   end
 
+  # Returns one of the "default" discord avatards from the CDN given a discriminator
+  def default_avatar(discrim = 0)
+    index = discrim.to_i % 5
+    "#{Discordrb::API.cdn_url}/embed/avatars/#{index}.png"
+  end
+
   # Make an avatar URL from the user and avatar IDs
   def avatar_url(user_id, avatar_id, format = nil)
     format ||= if avatar_id.start_with?('a_')

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -3286,9 +3286,9 @@ module Discordrb
     end
 
     # Utility function to get a webhook's avatar URL
-    # @return [String, nil] the URL to the avatar image (nil if no image is set).
+    # @return [String] the URL to the avatar image
     def avatar_url
-      return if @avatar.nil?
+      return API::User.default_avatar unless @avatar
       API::User.avatar_url(@id, @avatar)
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -135,9 +135,10 @@ module Discordrb
     end
 
     # Utility function to get a user's avatar URL.
-    # @param format [String, nil] If `nil`, the URL will default to `webp` for static avatars, and will detect if the user has a `gif` avatar. You can otherwise specify one of `webp`, `jpg`, `png`, or `gif` to override this.
+    # @param format [String, nil] If `nil`, the URL will default to `webp` for static avatars, and will detect if the user has a `gif` avatar. You can otherwise specify one of `webp`, `jpg`, `png`, or `gif` to override this. Will always be PNG for default avatars.
     # @return [String] the URL to the avatar image.
     def avatar_url(format = nil)
+      return API::User.default_avatar(@discriminator) unless @avatar_id
       API::User.avatar_url(@id, @avatar_id, format)
     end
   end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -155,7 +155,7 @@ module Discordrb
 
     describe '#avatar_url' do
       context 'avatar is set' do
-        it 'calls the API helper' do
+        it 'calls the correct API helper' do
           expect(API::User).to receive(:avatar_url).with(webhook_id, webhook_avatar)
           webhook.avatar_url
         end
@@ -164,13 +164,9 @@ module Discordrb
       context 'avatar is not set' do
         before { webhook.instance_variable_set(:@avatar, nil) }
 
-        it 'doesn\'t call API' do
-          expect(API::User).not_to receive(:avatar_url)
+        it 'calls the correct API helper' do
+          expect(API::User).to receive(:default_avatar)
           webhook.avatar_url
-        end
-
-        it 'returns nil' do
-          expect(webhook.avatar_url).to eq nil
         end
       end
     end


### PR DESCRIPTION
EdgeCases:tm:

![image](https://user-images.githubusercontent.com/6119032/28107110-6ca0c36c-66b4-11e7-86de-e72203e3dd9d.png)
