### PR TITLE
Advanced Functionality - empty string to disable

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -54,19 +54,19 @@ module Discordrb::Commands
     # @option attributes [Array<String, Integer, Channel>] :channels The channels this command bot accepts commands on.
     #   Superseded if a command has a 'channels' attribute.
     # @option attributes [String] :previous Character that should designate the result of the previous command in
-    #   a command chain (see :advanced_functionality). Default is '~'.
+    #   a command chain (see :advanced_functionality). Default is '~'. Set to an empty string to disable.
     # @option attributes [String] :chain_delimiter Character that should designate that a new command begins in the
-    #   command chain (see :advanced_functionality). Default is '>'.
+    #   command chain (see :advanced_functionality). Default is '>'. Set to an empty string to disable.
     # @option attributes [String] :chain_args_delim Character that should separate the command chain arguments from the
-    #   chain itself (see :advanced_functionality). Default is ':'.
+    #   chain itself (see :advanced_functionality). Default is ':'. Set to an empty string to disable.
     # @option attributes [String] :sub_chain_start Character that should start a sub-chain (see
-    #   :advanced_functionality). Default is '['.
+    #   :advanced_functionality). Default is '['. Set to an empty string to disable.
     # @option attributes [String] :sub_chain_end Character that should end a sub-chain (see
-    #   :advanced_functionality). Default is ']'.
+    #   :advanced_functionality). Default is ']'. Set to an empty string to disable.
     # @option attributes [String] :quote_start Character that should start a quoted string (see
-    #   :advanced_functionality). Default is '"'.
+    #   :advanced_functionality). Default is '"'. Set to an empty string to disable.
     # @option attributes [String] :quote_end Character that should end a quoted string (see
-    #   :advanced_functionality). Default is '"'.
+    #   :advanced_functionality). Default is '"' or the same as :quote_start. Set to an empty string to disable.
     # @option attributes [true, false] :ignore_bots Whether the bot should ignore bot accounts or not. Default is false.
     def initialize(attributes = {})
       super(
@@ -126,7 +126,7 @@ module Discordrb::Commands
         quote_start: attributes[:quote_start] || '"',
 
         # Quoted mode ending character
-        quote_end: attributes[:quote_end] || '"'
+        quote_end: attributes[:quote_end] || attributes[:quote_start] || '"'
       }
 
       @permissions = {

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -195,10 +195,14 @@ module Discordrb::Commands
       chain_to_split = @chain
 
       # Don't break if a command is called the same thing as the chain delimiter
-      chain_to_split = chain_to_split.slice(1..-1) if chain_to_split.start_with?(@attributes[:chain_delimiter])
+      chain_to_split = chain_to_split.slice(1..-1) if !@attributes[:chain_delimiter].empty? && chain_to_split.start_with?(@attributes[:chain_delimiter])
 
       first = true
-      split_chain = chain_to_split.split(@attributes[:chain_delimiter])
+      split_chain = if @attributes[:chain_delimiter].empty?
+                      [chain_to_split]
+                    else
+                      chain_to_split.split(@attributes[:chain_delimiter])
+                    end
       split_chain.each do |command|
         command = @attributes[:chain_delimiter] + command if first && @chain.start_with?(@attributes[:chain_delimiter])
         first = false
@@ -267,7 +271,7 @@ module Discordrb::Commands
     private
 
     def divide_chain(chain)
-      chain_args_index = chain.index @attributes[:chain_args_delim]
+      chain_args_index = @attributes[:chain_args_delim].empty? ? nil : chain.index(@attributes[:chain_args_delim])
       chain_args = []
 
       if chain_args_index

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -271,7 +271,7 @@ module Discordrb::Commands
     private
 
     def divide_chain(chain)
-      chain_args_index = @attributes[:chain_args_delim].empty? ? nil : chain.index(@attributes[:chain_args_delim])
+      chain_args_index = chain.index(@attributes[:chain_args_delim]) unless @attributes[:chain_args_delim].empty?
       chain_args = []
 
       if chain_args_index


### PR DESCRIPTION
My PR naming abilities haven't improved. Sorry.

Fixes a long-standing bug where setting `:chain_delimiter` or `:chain_args_delim` to an empty string while creating the bot causes any commands to fail. Inadvertently, this also enables developers to disable any specific piece of advanced functionality by setting the triggering characters to a empty string (`''`), so I've documented that as well.

Along the side, I also changed `:quote_end` to be the same as `:quote_start` if it's not specified, so people can specify just the start character if they want it to be the same for both.

P.S. I'm unsure if my methods of fixing these are really the best way -- if there's a better way or a way that's more readable, please let me know how and I'll be happy to change the code.