### PR TITLE
Update concept of "default channel" per API change

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2667,9 +2667,18 @@ module Discordrb
       @owner = member(@owner_id) if exists
     end
 
-    # @return [Channel] The default channel on this server (usually called #general)
+    # The default channel is the text channel on this server with the highest position
+    # that the client has Read Messages permission on.
+    # @return [Channel] The default channel on this server
     def default_channel
-      @bot.channel(@id)
+      text_channels.sort_by { |e| [e.position, e.id] }.find do |e|
+        overwrite = e.permission_overwrites[id]
+        if overwrite
+          overwrite.allow.read_messages || overwrite.allow.read_messages == overwrite.deny.read_messages
+        else
+          everyone_role.permissions.read_messages
+        end
+      end
     end
 
     alias_method :general_channel, :default_channel

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1564,9 +1564,7 @@ module Discordrb
     # in that channel. For a text channel, it will return all online members that have permission to read it.
     # @return [Array<Member>] the users in this channel
     def users
-      if default_channel?
-        @server.online_members(include_idle: true)
-      elsif text?
+      if text?
         @server.online_members(include_idle: true).select { |u| u.can_read_messages? self }
       elsif voice?
         @server.voice_states.map { |id, voice_state| @server.member(id) if !voice_state.voice_channel.nil? && voice_state.voice_channel.id == @id }.compact


### PR DESCRIPTION
Discord has (pending deployment at time of writing this PR) updated their API to remove the previous concept of the "default channel" being the channel with the same snowflake ID as the guild. It is now described as:

> ".. the channel with the highest position that their (the client) allows them to see (read)".

This API change also allows "default channels" to be deleted and hidden just like any other channel.

https://github.com/hammerandchisel/discord-api-docs/pull/329