### PR TITLE
Make sure to always ratelimit preemptively, fixes #378

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -114,7 +114,6 @@ module Discordrb::API
         if response
           handle_preemptive_rl(response, mutex, key) if response.headers[:x_ratelimit_remaining] == '0' && !mutex.locked?
         else
-          # technically this should never happen... but you know.
           Discordrb::LOGGER.ratelimit('Response was nil when trying to preemptively rate limit!!')
         end
       end

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -140,7 +140,7 @@ module Discordrb::API
   end
 
   def handle_preemptive_rl(response, mutex, key)
-    Discordrb::LOGGER.debug "RL bucket depletion detected! Date: #{response.headers[:date]} Reset: #{response.headers[:x_ratelimit_reset]}"
+    Discordrb::LOGGER.ratelimit "RL bucket depletion detected! Date: #{response.headers[:date]} Reset: #{response.headers[:x_ratelimit_reset]}"
 
     now = Time.rfc2822(response.headers[:date])
     reset = Time.at(response.headers[:x_ratelimit_reset].to_i)

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -138,6 +138,8 @@ module Discordrb::API
     response
   end
 
+  # Handles premeptive ratelimiting by waiting the given mutex by the difference of the Date header to the
+  # X-Ratelimit-Reset header in the given response, thus making sure we don't get 429'd in any subsequent requests.
   def handle_preemptive_rl(response, mutex, key)
     Discordrb::LOGGER.ratelimit "RL bucket depletion detected! Date: #{response.headers[:date]} Reset: #{response.headers[:x_ratelimit_reset]}"
 

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -114,7 +114,7 @@ module Discordrb::API
         if response
           handle_preemptive_rl(response.headers, mutex, key) if response.headers[:x_ratelimit_remaining] == '0' && !mutex.locked?
         else
-          Discordrb::LOGGER.ratelimit('Response was nil when trying to preemptively rate limit!!')
+          Discordrb::LOGGER.ratelimit('Response was nil before trying to preemptively rate limit!')
         end
       end
     rescue RestClient::TooManyRequests => e


### PR DESCRIPTION
So basically, issue #378 happens because the `#user` method has this block of code in it:
```ruby
begin
  response = API::User.resolve(token, id)
rescue RestClient::ResourceNotFound
  return nil
end
```
As you can see, the `rescue` block makes sure to return `nil` in case a user is not found. However, this is thrown by RestClient. In `#request`, we have this:
```ruby
response = raw_request(type, attributes)

if response.headers[:x_ratelimit_remaining] == '0' && !mutex.locked?
  # handles preemptive ratelimiting
end
```
All `raw_request` does is delegate to RestClient for the request, and when RestClient gets a 404 it raises a `ResourceNotFound` exception which is then caught by the rescue block in #user, thus skipping the preemptive ratelimiting completely, and since #user calls a 1/1 route, you get b1nzy'd.

All I did was wrap the `#raw_request` call into an `begin-ensure` block that calls `#handle_preemptive_rl` that does the preemptive ratelimiting, so this makes sure that the preemptive ratelimiting handling is _always_ ran no matter what. This seems to fix the issue.