### PR TITLE
Cache setters after the API is called on Discordrb::Channel

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1339,10 +1339,9 @@ module Discordrb
     # @raise [ArguementError] if value isn't one of true, false
     def nsfw=(value)
       raise ArgumentError, 'nsfw value must be true or false' unless value.is_a?(TrueClass) || value.is_a?(FalseClass)
-      @nsfw = value
       update_channel_data
 
-      @nsfw
+      @nsfw = value
     end
 
     # This channel's permission overwrites
@@ -1450,32 +1449,32 @@ module Discordrb
     # Sets this channel's name. The name must be alphanumeric with dashes, unless this is a voice channel (then there are no limitations)
     # @param name [String] The new name.
     def name=(name)
-      @name = name
       update_channel_data
+      @name = name
     end
 
     # Sets this channel's topic.
     # @param topic [String] The new topic.
     def topic=(topic)
       raise 'Tried to set topic on voice channel' if voice?
-      @topic = topic
       update_channel_data
+      @topic = topic
     end
 
     # Sets this channel's bitrate.
     # @param bitrate [Integer] The new bitrate (in bps). Number has to be between 8000-96000 (128000 for VIP servers)
     def bitrate=(bitrate)
       raise 'Tried to set bitrate on text channel' if text?
-      @bitrate = bitrate
       update_channel_data
+      @bitrate = bitrate
     end
 
     # Sets this channel's user limit.
     # @param limit [Integer] The new user limit. `0` for unlimited, has to be a number between 0-99
     def user_limit=(limit)
       raise 'Tried to set user_limit on text channel' if text?
-      @user_limit = limit
       update_channel_data
+      @user_limit = limit
     end
 
     alias_method :limit=, :user_limit=
@@ -1483,8 +1482,8 @@ module Discordrb
     # Sets this channel's position in the list.
     # @param position [Integer] The new position.
     def position=(position)
-      @position = position
       update_channel_data
+      @position = position
     end
 
     # Updates this channel's settings.

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -41,6 +41,17 @@ module Discordrb
         channel.nsfw = true
         expect(channel.nsfw).to eq true
       end
+
+      context 'when the API raises an error' do
+        it 'should not change the cached value' do
+          allow(channel).to receive(:update_channel_data).and_raise(Discordrb::Errors::NoPermission)
+          begin
+            channel.nsfw = true
+          rescue Discordrb::Errors::NoPermission
+            expect(channel.nsfw).to eq false
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #388 
Due for extra specs after the data.rb rework.

I checked through the rest of the data class setters and they all use a common method for requesting updates and then caching after the call so don't need to be changed. Perhaps rework the way Channel sets/caches to keep consistent with the rest of the library.