### PR TITLE
Cache channels before updating server data, fixes #374

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2683,17 +2683,17 @@ module Discordrb
     end
 
     # @return [true, false] whether or not the server has widget enabled
-    def embed?
-      update_data if @embed.nil?
-      @embed
+    def embed_enabled?
+      update_data if @embed_enabled.nil?
+      @embed_enabled
     end
-    alias_method :widget_enabled, :embed?
-    alias_method :widget?, :embed?
-    alias_method :embed_enabled, :embed?
+    alias_method :widget_enabled, :embed_enabled?
+    alias_method :widget?, :embed_enabled?
+    alias_method :embed?, :embed_enabled?
 
     # @return [Channel, nil] the channel the server embed will make a invite for.
     def embed_channel
-      update_data if @embed.nil?
+      update_data if @embed_enabled.nil?
       @bot.channel(@embed_channel_id) if @embed_channel_id
     end
     alias_method :widget_channel, :embed_channel
@@ -2747,8 +2747,8 @@ module Discordrb
     # @return [String, nil] the widget URL to the server that displays the amount of online members in a
     #   stylish way. `nil` if the widget is not enabled.
     def widget_url
-      update_data if @embed.nil?
-      return nil unless @embed
+      update_data if @embed_enabled.nil?
+      return unless @embed_enabled
       API.widget_url(@id)
     end
 
@@ -2761,8 +2761,8 @@ module Discordrb
     # @return [String, nil] the widget banner URL to the server that displays the amount of online members,
     #   server icon and server name in a stylish way. `nil` if the widget is not enabled.
     def widget_banner_url(style)
-      update_data if @embed.nil?
-      return nil unless @embed
+      update_data if @embed_enabled.nil?
+      return unless @embed_enabled
       API.widget_url(@id, style)
     end
 
@@ -3056,7 +3056,7 @@ module Discordrb
       embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'] || @embed_channel
       @embed_channel_id = embed_channel_id.nil? ? nil : embed_channel_id.resolve_id
 
-      @embed = new_data[:embed_enabled] || new_data['embed_enabled'] || @embed
+      @embed_enabled = new_data[:embed_enabled] || new_data['embed_enabled']
       @verification_level = %i[none low medium high very_high][new_data['verification_level']] || @verification_level
       @explicit_content_filter = %i[none exclude_roles all][new_data['explicit_content_filter']] || @explicit_content_filter
       @default_message_notifications = %i[all mentions][new_data['default_message_notifications']] || @default_message_notifications

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2599,6 +2599,8 @@ module Discordrb
       @bot = bot
       @owner_id = data['owner_id'].to_i
       @id = data['id'].to_i
+      
+      process_channels(data['channels'])
       update_data(data)
 
       @large = data['large']
@@ -2614,7 +2616,6 @@ module Discordrb
       process_emoji(data['emojis'])
       process_members(data['members'])
       process_presences(data['presences'])
-      process_channels(data['channels'])
       process_voice_states(data['voice_states'])
 
       # Whether this server's members have been chunked (resolved using op 8 and GUILD_MEMBERS_CHUNK) yet

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -3049,9 +3049,13 @@ module Discordrb
       @name = new_data[:name] || new_data['name'] || @name
       @region_id = new_data[:region] || new_data['region'] || @region_id
       @icon_id = new_data[:icon] || new_data['icon'] || @icon_id
-      @afk_timeout = new_data[:afk_timeout] || new_data['afk_timeout'].to_i || @afk_timeout
-      @afk_channel_id = new_data[:afk_channel_id] || new_data['afk_channel_id'].to_i || @afk_channel.id
-      @embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'].to_i || @embed_channel.id
+      @afk_timeout = new_data[:afk_timeout] || new_data['afk_timeout'] || @afk_timeout
+
+      afk_channel_id = new_data[:afk_channel_id] || new_data['afk_channel_id'] || @afk_channel
+      @afk_channel_id = afk_channel_id.nil? ? nil : afk_channel_id.resolve_id
+      embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'] || @embed_channel
+      @embed_channel_id = embed_channel_id.nil? ? nil : embed_channel_id.resolve_id
+
       @embed = new_data[:embed_enabled] || new_data['embed_enabled'] || @embed
       @verification_level = %i[none low medium high very_high][new_data['verification_level']] || @verification_level
       @explicit_content_filter = %i[none exclude_roles all][new_data['explicit_content_filter']] || @explicit_content_filter


### PR DESCRIPTION
This fixes a bug where channels we don't have access to (because we can't Read Messages or Connect) are attempted to be resolved by `GET /channels/{cid}`, when in fact, we already have the data for these channels in `GUILD_CREATE` and can properly cache them from there.

For example, this would cause exceptions to be raised every time a user joins or leaves (voice state update) a voice channel that denies Connect to our client.

For more information on this behavior, see https://github.com/meew0/discordrb/issues/374#issuecomment-313839853

The logic in `update_data` that refers to a channel being "unavailable" and setting AFK channels to nil can probably be removed, and maybe the embed_channel as well, but I need to look into this more closely to tidy it up. Opening this PR as a placeholder in the meantime.

---

Todo:
- [x] Move `update_data` back up, but place `process_channels` before it to isolate any future edge cases
- [x] Remove "unavailable channel" exception check for `@afk_channel`
- [x] Remove "unavailable channel" exception check for `@embed_channel`
- [x] Fix `||` logic in some `update_data` statements