### PR TITLE
Document that Server#default_channel will be nil if the bot cannot read any channels

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2666,7 +2666,7 @@ module Discordrb
 
     # The default channel is the text channel on this server with the highest position
     # that the client has Read Messages permission on.
-    # @return [Channel] The default channel on this server
+    # @return [Channel, nil] The default channel on this server, or nil if there are no channels that the bot can read
     def default_channel
       text_channels.sort_by { |e| [e.position, e.id] }.find do |e|
         overwrite = e.permission_overwrites[id]


### PR DESCRIPTION
Because it's entirely possible to have no channels in a server, or more commonly, to have a server where the bot cannot read any of the channels.