### PR TITLE
Much embed cleanup. So accessor. Wow.

### DIFF
--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -19,22 +19,22 @@ module Discordrb::Webhooks
     end
 
     # The title of this embed that will be displayed above everything else.
-    # @return [String]
+    # @return [String, nil] title of the embed, or `nil` if none was set during initialization
     attr_accessor :title
 
     # The description for this embed.
-    # @return [String]
+    # @return [String, nil] description for this embed, or `nil` if none was set during initialization
     attr_accessor :description
 
     # The URL the title should point to.
-    # @return [String]
+    # @return [String, nil] URL the title should point to, or `nil` if none was set during initialization
     attr_accessor :url
 
     # The timestamp for this embed. Will be displayed just below the title.
-    # @return [Time]
+    # @return [Time, nil] timestamp for this embed, or `nil` if none was set during initialization
     attr_accessor :timestamp
 
-    # @return [Integer] the colour of the bar to the side, in decimal form.
+    # @return [Integer, nil] the colour of the bar to the side, in decimal form, or `nil` if none was set during initialization
     attr_reader :colour
     alias_method :color, :colour
 
@@ -58,28 +58,28 @@ module Discordrb::Webhooks
     # The footer for this embed.
     # @example Add a footer to an embed
     #   embed.footer = Discordrb::Webhooks::EmbedFooter.new(text: 'Hello', icon_url: 'https://i.imgur.com/j69wMDu.jpg')
-    # @return [EmbedFooter]
+    # @return [EmbedFooter, nil] footer for this embed, or `nil` if none was set during initialization
     attr_accessor :footer
 
     # The image for this embed.
     # @see EmbedImage
     # @example Add a image to an embed
     #   embed.image = Discordrb::Webhooks::EmbedImage.new(url: 'https://i.imgur.com/PcMltU7.jpg')
-    # @return [EmbedImage]
+    # @return [EmbedImage, nil] image for this embed, or `nil` if none was set during initialization
     attr_accessor :image
 
     # The thumbnail for this embed.
     # @see EmbedThumbnail
     # @example Add a thumbnail to an embed
     #   embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: 'https://i.imgur.com/xTG3a1I.jpg')
-    # @return [EmbedThumbnail]
+    # @return [EmbedThumbnail, nil] thumbnail for this embed, or `nil` if none was set during initialization
     attr_accessor :thumbnail
 
     # The author for this embed.
     # @see EmbedAuthor
     # @example Add a author to an embed
     #   embed.author = Discordrb::Webhooks::EmbedAuthor.new(name: 'meew0', url: 'https://github.com/meew0', icon_url: 'https://avatars2.githubusercontent.com/u/3662915?v=3&s=466')
-    # @return [EmbedAuthor]
+    # @return [EmbedAuthor, nil] author for this embed, or `nil` if none was set during initialization
     attr_accessor :author
 
     # Add a field object to this embed.
@@ -100,7 +100,7 @@ module Discordrb::Webhooks
     end
 
     # @return [Array<EmbedField>] the fields attached to this embed.
-    attr_reader :fields
+    attr_accessor :fields
 
     # @return [Hash] a hash representation of this embed, to be converted to JSON.
     def to_hash
@@ -124,6 +124,14 @@ module Discordrb::Webhooks
   # An embed's footer will be displayed at the very bottom of an embed, together with the timestamp. An icon URL can be
   # set together with some text to be displayed.
   class EmbedFooter
+    # The text to be displayed in the footer.
+    # @return [String, nil] text to be displayed in the footer, or `nil` if none was set during initialization
+    attr_accessor :text
+
+    # The URL to an icon to be showed alongside the text.
+    # @return [String, nil] URL to an icon to be showed alongside the text, or `nil` if none was set during initialization
+    attr_accessor :icon_url
+
     # Creates a new footer object.
     # @param text [String, nil] The text to be displayed in the footer.
     # @param icon_url [String, nil] The URL to an icon to be showed alongside the text.
@@ -143,6 +151,10 @@ module Discordrb::Webhooks
 
   # An embed's image will be displayed at the bottom, in large format. It will replace a footer icon URL if one is set.
   class EmbedImage
+    # The URL of the image
+    # @return [String, nil] URL of the image, or `nil` if none was set during initialization
+    attr_accessor :url
+
     # Creates a new image object.
     # @param url [String, nil] The URL of the image.
     def initialize(url: nil)
@@ -160,6 +172,10 @@ module Discordrb::Webhooks
   # An embed's thumbnail will be displayed at the right of the message, next to the description and fields. When clicked
   # it will point to the embed URL.
   class EmbedThumbnail
+    # The URL of the thumbnail.
+    # @return [String, nil] URL of the thumbnail, or `nil` if none was set during initialization
+    attr_accessor :url
+
     # Creates a new thumbnail object.
     # @param url [String, nil] The URL of the thumbnail.
     def initialize(url: nil)
@@ -176,6 +192,18 @@ module Discordrb::Webhooks
 
   # An embed's author will be shown at the top to indicate who "authored" the particular event the webhook was sent for.
   class EmbedAuthor
+    # The name of the author.
+    # @return [String, nil] name of the author, or `nil` if none was set during initialization
+    attr_accessor :name
+
+    # The URL the name should link to.
+    # @return [String, nil] URL the name should link to, or `nil` if none was set during initialization
+    attr_accessor :url
+
+    # The URL of the icon to be displayed next to the author.
+    # @return [String, nil] URL of the icon to be displayed next to the author, or `nil` if none was set during initialization
+    attr_accessor :icon_url
+
     # Creates a new author object.
     # @param name [String, nil] The name of the author.
     # @param url [String, nil] The URL the name should link to.
@@ -198,11 +226,23 @@ module Discordrb::Webhooks
 
   # A field is a small block of text with a header that can be relatively freely layouted with other fields.
   class EmbedField
+    # The name of the field, displayed in bold at the top of the field.
+    # @return [String, nil] name of the field, or `nil` if none was set during initialization
+    attr_accessor :name
+
+    # The value of the field, displayed in normal text below the name.
+    # @return [String, nil] value of the field, or `nil` if none was set during initialization
+    attr_accessor :value
+
+    # Whether the field should be displayed inline with other fields.
+    # @return [true, false] whether the field should be displayed inline with other fields. Defaults to false.
+    attr_accessor :inline
+
     # Creates a new field object.
-    # @param name [String, nil] The name of the field, displayed in bold at the top.
+    # @param name [String, nil] The name of the field, displayed in bold at the top of the field.
     # @param value [String, nil] The value of the field, displayed in normal text below the name.
-    # @param inline [true, false] Whether the field should be displayed in-line with other fields.
-    def initialize(name: nil, value: nil, inline: nil)
+    # @param inline [true, false] Whether the field should be displayed inline with other fields. Defaults to false.
+    def initialize(name: nil, value: nil, inline: false)
       @name = name
       @value = value
       @inline = inline

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -30,7 +30,7 @@ module Discordrb::Webhooks
     # @return [Time, nil] timestamp for this embed. Will be displayed just below the title.
     attr_accessor :timestamp
 
-    # @return [Integer, nil] the colour of the bar to the side, in decimal form, or `nil` if none was set during initialization
+    # @return [Integer, nil] the colour of the bar to the side, in decimal form
     attr_reader :colour
     alias_method :color, :colour
 

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -18,20 +18,16 @@ module Discordrb::Webhooks
       @fields = fields
     end
 
-    # The title of this embed that will be displayed above everything else.
-    # @return [String, nil] title of the embed, or `nil` if none was set during initialization
+    # @return [String, nil] title of the embed that will be displayed above everything else.
     attr_accessor :title
 
-    # The description for this embed.
-    # @return [String, nil] description for this embed, or `nil` if none was set during initialization
+    # @return [String, nil] description for this embed
     attr_accessor :description
 
-    # The URL the title should point to.
-    # @return [String, nil] URL the title should point to, or `nil` if none was set during initialization
+    # @return [String, nil] URL the title should point to
     attr_accessor :url
 
-    # The timestamp for this embed. Will be displayed just below the title.
-    # @return [Time, nil] timestamp for this embed, or `nil` if none was set during initialization
+    # @return [Time, nil] timestamp for this embed. Will be displayed just below the title.
     attr_accessor :timestamp
 
     # @return [Integer, nil] the colour of the bar to the side, in decimal form, or `nil` if none was set during initialization
@@ -55,31 +51,27 @@ module Discordrb::Webhooks
 
     alias_method :color=, :colour=
 
-    # The footer for this embed.
     # @example Add a footer to an embed
     #   embed.footer = Discordrb::Webhooks::EmbedFooter.new(text: 'Hello', icon_url: 'https://i.imgur.com/j69wMDu.jpg')
-    # @return [EmbedFooter, nil] footer for this embed, or `nil` if none was set during initialization
+    # @return [EmbedFooter, nil] footer for this embed
     attr_accessor :footer
 
-    # The image for this embed.
     # @see EmbedImage
     # @example Add a image to an embed
     #   embed.image = Discordrb::Webhooks::EmbedImage.new(url: 'https://i.imgur.com/PcMltU7.jpg')
-    # @return [EmbedImage, nil] image for this embed, or `nil` if none was set during initialization
+    # @return [EmbedImage, nil] image for this embed
     attr_accessor :image
 
-    # The thumbnail for this embed.
     # @see EmbedThumbnail
     # @example Add a thumbnail to an embed
     #   embed.thumbnail = Discordrb::Webhooks::EmbedThumbnail.new(url: 'https://i.imgur.com/xTG3a1I.jpg')
-    # @return [EmbedThumbnail, nil] thumbnail for this embed, or `nil` if none was set during initialization
+    # @return [EmbedThumbnail, nil] thumbnail for this embed
     attr_accessor :thumbnail
 
-    # The author for this embed.
     # @see EmbedAuthor
     # @example Add a author to an embed
     #   embed.author = Discordrb::Webhooks::EmbedAuthor.new(name: 'meew0', url: 'https://github.com/meew0', icon_url: 'https://avatars2.githubusercontent.com/u/3662915?v=3&s=466')
-    # @return [EmbedAuthor, nil] author for this embed, or `nil` if none was set during initialization
+    # @return [EmbedAuthor, nil] author for this embed
     attr_accessor :author
 
     # Add a field object to this embed.
@@ -124,12 +116,10 @@ module Discordrb::Webhooks
   # An embed's footer will be displayed at the very bottom of an embed, together with the timestamp. An icon URL can be
   # set together with some text to be displayed.
   class EmbedFooter
-    # The text to be displayed in the footer.
-    # @return [String, nil] text to be displayed in the footer, or `nil` if none was set during initialization
+    # @return [String, nil] text to be displayed in the footer
     attr_accessor :text
 
-    # The URL to an icon to be showed alongside the text.
-    # @return [String, nil] URL to an icon to be showed alongside the text, or `nil` if none was set during initialization
+    # @return [String, nil] URL to an icon to be showed alongside the text
     attr_accessor :icon_url
 
     # Creates a new footer object.
@@ -151,8 +141,7 @@ module Discordrb::Webhooks
 
   # An embed's image will be displayed at the bottom, in large format. It will replace a footer icon URL if one is set.
   class EmbedImage
-    # The URL of the image
-    # @return [String, nil] URL of the image, or `nil` if none was set during initialization
+    # @return [String, nil] URL of the image
     attr_accessor :url
 
     # Creates a new image object.
@@ -172,8 +161,7 @@ module Discordrb::Webhooks
   # An embed's thumbnail will be displayed at the right of the message, next to the description and fields. When clicked
   # it will point to the embed URL.
   class EmbedThumbnail
-    # The URL of the thumbnail.
-    # @return [String, nil] URL of the thumbnail, or `nil` if none was set during initialization
+    # @return [String, nil] URL of the thumbnail
     attr_accessor :url
 
     # Creates a new thumbnail object.
@@ -192,16 +180,13 @@ module Discordrb::Webhooks
 
   # An embed's author will be shown at the top to indicate who "authored" the particular event the webhook was sent for.
   class EmbedAuthor
-    # The name of the author.
-    # @return [String, nil] name of the author, or `nil` if none was set during initialization
+    # @return [String, nil] name of the author
     attr_accessor :name
 
-    # The URL the name should link to.
-    # @return [String, nil] URL the name should link to, or `nil` if none was set during initialization
+    # @return [String, nil] URL the name should link to
     attr_accessor :url
 
-    # The URL of the icon to be displayed next to the author.
-    # @return [String, nil] URL of the icon to be displayed next to the author, or `nil` if none was set during initialization
+    # @return [String, nil] URL of the icon to be displayed next to the author
     attr_accessor :icon_url
 
     # Creates a new author object.
@@ -226,22 +211,19 @@ module Discordrb::Webhooks
 
   # A field is a small block of text with a header that can be relatively freely layouted with other fields.
   class EmbedField
-    # The name of the field, displayed in bold at the top of the field.
-    # @return [String, nil] name of the field, or `nil` if none was set during initialization
+    # @return [String, nil] name of the field, displayed in bold at the top of the field.
     attr_accessor :name
 
-    # The value of the field, displayed in normal text below the name.
-    # @return [String, nil] value of the field, or `nil` if none was set during initialization
+    # @return [String, nil] value of the field, displayed in normal text below the name.
     attr_accessor :value
 
-    # Whether the field should be displayed inline with other fields.
-    # @return [true, false] whether the field should be displayed inline with other fields. Defaults to false.
+    # @return [true, false] whether the field should be displayed inline with other fields.
     attr_accessor :inline
 
     # Creates a new field object.
     # @param name [String, nil] The name of the field, displayed in bold at the top of the field.
     # @param value [String, nil] The value of the field, displayed in normal text below the name.
-    # @param inline [true, false] Whether the field should be displayed inline with other fields. Defaults to false.
+    # @param inline [true, false] Whether the field should be displayed inline with other fields.
     def initialize(name: nil, value: nil, inline: false)
       @name = name
       @value = value


### PR DESCRIPTION
Just some cleanup for the embed classes.

- All attribute used in `EmbedAuthor`, `EmbedField`, `EmbedFooter`, `EmbedImage` and `EmbedThumbnail` are now exposed as attributes. No more `#instance_variable_get` and `#instance_variable_set` for the devs who wanted (or needed) to get/set them afterwards.
- Documentation, documentation, documentation. More specifically, I documented that most attributes in the above classes (as well as `Embed`) will be `nil` by default if not set when first instancing the class.
- `EmbedField`'s `inline` attribute now defaults to false, as Discord defaults it to false anyways. (Tested by forcing a hash without `inline` defined to be sent) This change should not affect existing bots except where they were checking if `inline` is explicitly `nil`.
- The `fields` attribute within `Embed` is now an accessor rather than a reader. While we have `Embed#<<` and `Embed#add_field`, there is no reason we should be required to use them to add a field, especially when we allow setting `fields` to anything we want when instancing `Embed` anyways.
- Also apparently I fixed two Code Climate issues????