### PR TITLE
Fix arg typo for Argument Error in CommandBot

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -283,7 +283,7 @@ module Discordrb::Commands
             nil
           end
         else
-          raise ArgumentError, "#{type} doesn't implement from_argument"
+          raise ArgumentError, "#{types[i]} doesn't implement from_argument"
         end
       end
     end


### PR DESCRIPTION
As noted by Ghosty in Discord, `type` is never defined.