### PR TITLE
Remove superfluous spaces in abbreviations in the docs

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -15,7 +15,7 @@ end
 
 # In discordrb, Integer and {String} are monkey-patched to allow for easy resolution of IDs
 class Integer
-  # @return [Integer] The Discord ID represented by this integer, i. e. the integer itself
+  # @return [Integer] The Discord ID represented by this integer, i.e. the integer itself
   def resolve_id
     self
   end
@@ -23,7 +23,7 @@ end
 
 # In discordrb, {Integer} and String are monkey-patched to allow for easy resolution of IDs
 class String
-  # @return [Integer] The Discord ID represented by this string, i. e. the string converted to an integer
+  # @return [Integer] The Discord ID represented by this string, i.e. the string converted to an integer
   def resolve_id
     to_i
   end

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -98,7 +98,7 @@ module Discordrb::API
     begin
       mutex = @mutexes[key] ||= Mutex.new
 
-      # Lock and unlock, i. e. wait for the mutex to unlock and don't do anything with it afterwards
+      # Lock and unlock, i.e. wait for the mutex to unlock and don't do anything with it afterwards
       mutex_wait(mutex)
 
       # If the global mutex happens to be locked right now, wait for that as well.

--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -187,9 +187,9 @@ module Discordrb
     #
     #    * An {Invite} object
     #    * The code for an invite
-    #    * A fully qualified invite URL (e. g. `https://discordapp.com/invite/0A37aN7fasF7n83q`)
-    #    * A short invite URL with protocol (e. g. `https://discord.gg/0A37aN7fasF7n83q`)
-    #    * A short invite URL without protocol (e. g. `discord.gg/0A37aN7fasF7n83q`)
+    #    * A fully qualified invite URL (e.g. `https://discordapp.com/invite/0A37aN7fasF7n83q`)
+    #    * A short invite URL with protocol (e.g. `https://discord.gg/0A37aN7fasF7n83q`)
+    #    * A short invite URL without protocol (e.g. `discord.gg/0A37aN7fasF7n83q`)
     # @return [String] Only the code for the invite.
     def resolve_invite_code(invite)
       invite = invite.code if invite.is_a? Discordrb::Invite

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -37,7 +37,7 @@ module Discordrb
       register_event(MessageEvent, attributes, block)
     end
 
-    # This **event** is raised when the READY packet is received, i. e. servers and channels have finished
+    # This **event** is raised when the READY packet is received, i.e. servers and channels have finished
     # initialization. It's the recommended way to do things when the bot has finished starting up.
     # @param attributes [Hash] Event attributes, none in this particular case
     # @yield The block is executed when the event is raised.
@@ -305,7 +305,7 @@ module Discordrb
       register_event(UserUnbanEvent, attributes, block)
     end
 
-    # This **event** is raised when a server is created respective to the bot, i. e. the bot joins a server or creates
+    # This **event** is raised when a server is created respective to the bot, i.e. the bot joins a server or creates
     # a new one itself. It should never be necessary to listen to this event as it will only ever be triggered by
     # things the bot itself does, but one can never know.
     # @param attributes [Hash] The event's attributes.
@@ -499,7 +499,7 @@ module Discordrb
     # Returns the event class for a handler class type
     # @see #handler_class
     # @param handler_class [Class] The handler type
-    # @return [Class, nil] the event type, or nil if the handler_class isn't a handler class (i. e. ends with Handler)
+    # @return [Class, nil] the event type, or nil if the handler_class isn't a handler class (i.e. ends with Handler)
     def self.event_class(handler_class)
       class_name = handler_class.to_s
       return nil unless class_name.end_with? 'Handler'

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -128,7 +128,7 @@ module Discordrb
       "<@#{@id}>"
     end
 
-    # Utility function to get Discord's distinct representation of a user, i. e. username + discriminator
+    # Utility function to get Discord's distinct representation of a user, i.e. username + discriminator
     # @return [String] distinct representation of user
     def distinct
       "#{@username}##{@discriminator}"

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -353,7 +353,7 @@ module Discordrb
       defined_permission?(action, channel)
     end
 
-    # Checks whether this user has a particular permission defined (i. e. not implicit, through for example
+    # Checks whether this user has a particular permission defined (i.e. not implicit, through for example
     # Manage Roles)
     # @param action [Symbol] The permission that should be checked. See also {Permissions::Flags} for a list.
     # @param channel [Channel, nil] If channel overrides should be checked too, this channel specifies where the overrides should be checked.
@@ -798,7 +798,7 @@ module Discordrb
 
     # Changes the bot's avatar.
     # @param avatar [String, #read] A JPG file to be used as the avatar, either
-    #  something readable (e. g. File Object) or as a data URL.
+    #  something readable (e.g. File Object) or as a data URL.
     def avatar=(avatar)
       if avatar.respond_to? :read
         # Set the file to binary mode if supported, so we don't get problems with Windows
@@ -1510,9 +1510,9 @@ module Discordrb
     #   @param reason [String] The reason the for defining the overwrite.
     # @overload define_overwrite(thing, allow, deny)
     #   @param thing [User, Role] What to define an overwrite for.
-    #   @param allow [#bits, Permissions, Integer] The permission sets that should receive an `allow` override (i. e. a
+    #   @param allow [#bits, Permissions, Integer] The permission sets that should receive an `allow` override (i.e. a
     #     green checkmark on Discord)
-    #   @param deny [#bits, Permissions, Integer] The permission sets that should receive a `deny` override (i. e. a red
+    #   @param deny [#bits, Permissions, Integer] The permission sets that should receive a `deny` override (i.e. a red
     #     cross on Discord)
     #   @param reason [String] The reason the for defining the overwrite.
     #   @example Define a permission overwrite for a user that can then mention everyone and use TTS, but not create any invites
@@ -2548,7 +2548,7 @@ module Discordrb
     include IDObject
     include ServerAttributes
 
-    # @return [String] the ID of the region the server is on (e. g. `amsterdam`).
+    # @return [String] the ID of the region the server is on (e.g. `amsterdam`).
     attr_reader :region_id
 
     # @return [Member] The server owner.
@@ -2621,7 +2621,7 @@ module Discordrb
       @chunked = false
       @processed_chunk_members = 0
 
-      # Only get the owner of the server actually exists (i. e. not for ServerDeleteEvent)
+      # Only get the owner of the server actually exists (i.e. not for ServerDeleteEvent)
       @owner = member(@owner_id) if exists
     end
 
@@ -2894,7 +2894,7 @@ module Discordrb
     end
 
     # Creates a role on this server which can then be modified. It will be initialized
-    # with the regular role defaults the client uses unless specified, i. e. name is "new role",
+    # with the regular role defaults the client uses unless specified, i.e. name is "new role",
     # permissions are the default, colour is the default etc.
     # @param name [String] Name of the role to create
     # @param colour [ColourRGB] The roles colour

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -167,7 +167,7 @@ module Discordrb
       LOGGER.debug('Confirmation received! Exiting run.')
     end
 
-    # Prevents all further execution until the websocket thread stops (e. g. through a closed connection).
+    # Prevents all further execution until the websocket thread stops (e.g. through a closed connection).
     def sync
       @ws_thread.join
     end
@@ -463,7 +463,7 @@ module Discordrb
           wait_for_reconnect
         end
 
-        # Restart the loop, i. e. reconnect
+        # Restart the loop, i.e. reconnect
       end
     end
 

--- a/lib/discordrb/light.rb
+++ b/lib/discordrb/light.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb/light/light_bot'
 
-# This module contains classes to allow connections to bots without a connection to the gateway socket, i. e. bots
+# This module contains classes to allow connections to bots without a connection to the gateway socket, i.e. bots
 # that only use the REST part of the API.
 module Discordrb::Light
 end


### PR DESCRIPTION
the spaces cause issues sometimes.
thanks yardoc