### PR TITLE
Implement ServerBan, provide ban reason querystring

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -188,10 +188,9 @@ module Discordrb::API::Server
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason ? "&reason=#{reason}" : ''}",
       nil,
-      Authorization: token,
-      'X-Audit-Log-Reason': reason
+      Authorization: token
     )
   end
 


### PR DESCRIPTION
This adds a data object for server ban objects, which includes the reason field.

Additionally, the X-Audit-Log-Reason header only provides a reason *in the audit log*, and not on the ban object itself. The reason querystring that is provided is what reason will be shown on the ban object itself, and also takes priority over the header.

Ref #309 

Bonus: Adds `Member#ban`, `Member#kick`