### PR TITLE
Implement channel categories

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -16,13 +16,13 @@ module Discordrb::API::Channel
 
   # Update a channel's data
   # https://discordapp.com/developers/docs/resources/channel#modify-channel
-  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, reason = nil)
+  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, permission_overwrites, parent_id, reason = nil)
     Discordrb::API.request(
       :channels_cid,
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}",
-      { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw }.to_json,
+      { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw, permission_overwrites: permission_overwrites, parent_id: parent_id }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -97,17 +97,16 @@ module Discordrb::API::Server
   end
 
   # Update a channels position
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel
-  def update_channel(token, server_id, channel_id, position, reason = nil)
+  # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions
+  def update_channel_positions(token, server_id, positions)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      { id: channel_id, position: position }.to_json,
+      positions.to_json,
       Authorization: token,
-      content_type: :json,
-      'X-Audit-Log-Reason': reason
+      content_type: :json
     )
   end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1221,11 +1221,23 @@ module Discordrb
   class Channel
     include IDObject
 
+    # Map of channel types
+    TYPES = {
+      text: 0,
+      dm: 1,
+      voice: 2,
+      group: 3,
+      category: 4
+    }.freeze
+
     # @return [String] this channel's name.
     attr_reader :name
 
     # @return [Server, nil] the server this channel is on. If this channel is a PM channel, it will be nil.
     attr_reader :server
+
+    # @return [Integer, nil] the ID of the parent channel, if this channel is inside a cateogry
+    attr_reader :parent_id
 
     # @return [Integer] the type of this channel (0: text, 1: private, 2: voice, 3: group)
     attr_reader :type
@@ -1281,6 +1293,7 @@ module Discordrb
       @user_limit = data['user_limit']
       @position = data['position']
       @nsfw = data['nsfw']
+      @parent_id = data['parent_id'].to_i
 
       if private?
         @recipients = []
@@ -1334,6 +1347,30 @@ module Discordrb
       @type == 3
     end
 
+    # @return [true, false]
+    def category?
+      @type == 4
+    end
+
+    # @return [Channel, nil] the category channel, if this channel is in a category
+    def category
+      @bot.channel(@parent_id) if @parent_id
+    end
+
+    alias_method :parent, :category
+
+    # Sets this channels parent category
+    # @param channel [Channel, #resolve_id] the target category channel
+    # @raise [ArgumentError] if the target channel isn't a category
+    def category=(channel)
+      channel = @bot.channel(channel)
+      raise ArgumentError, 'Cannot set parent category to a channel that isn\'t a category' unless channel.category?
+      @parent_id = channel.id
+      update_channel_data
+    end
+
+    alias_method :parent=, :category=
+
     # Sets whether this channel is NSFW
     # @param value [true, false]
     # @raise [ArguementError] if value isn't one of true, false
@@ -1359,6 +1396,39 @@ module Discordrb
     end
 
     alias_method :overwrites, :permission_overwrites
+
+    # Bulk sets this channels permission overwrites
+    # @param overwrites [Array<Overwrite>]
+    def permission_overwrites=(overwrites)
+      @permission_overwrites = overwrites
+      update_channel_data
+    end
+
+    # Syncs this channels overwrites with its parent category
+    # @raises [RuntimeError] if this channel is not in a category
+    def sync_overwrites
+      raise 'Cannot sync overwrites on a channel with no parent category' unless parent
+      self.permission_overwrites = parent.permission_overwrites
+    end
+
+    alias_method :sync, :sync_overwrites
+
+    # @return [true, false, nil] whether this channels permissions match the permission overwrites of the category that it's in, or nil if it is not in a category
+    def synchronized?
+      return unless parent
+      permission_overwrites == parent.permission_overwrites
+    end
+
+    alias_method :synced?, :synchronized?
+
+    # Returns the children of this channel, if it is a category
+    # @return [Array<Channel>]
+    def children
+      return [] unless category?
+      server.channels.select { |c| c.parent_id == id }
+    end
+
+    alias_method :channels, :children
 
     # @return [Overwrite] any member-type permission overwrites on this channel
     def member_overwrites
@@ -1784,7 +1854,8 @@ module Discordrb
     end
 
     def update_channel_data
-      API::Channel.update(@bot.token, @id, @name, @topic, @position, @bitrate, @user_limit, @nsfw, nil)
+      overwrites = @permission_overwrites.map { |_, v| v.to_hash }
+      API::Channel.update(@bot.token, @id, @name, @topic, @position, @bitrate, @user_limit, @nsfw, overwrites, @parent_id, nil)
     end
   end
 
@@ -2762,6 +2833,11 @@ module Discordrb
       @channels.select(&:voice?)
     end
 
+    # @return [Array<Channel>] an array of category channels on this server
+    def categories
+      @channels.select(&:category?)
+    end
+
     # @return [String, nil] the widget URL to the server that displays the amount of online members in a
     #   stylish way. `nil` if the widget is not enabled.
     def widget_url
@@ -2878,16 +2954,17 @@ module Discordrb
 
     # Creates a channel on this server with the given name.
     # @param name [String] Name of the channel to create
-    # @param type [Integer] Type of channel to create (0: text, 2: voice)
+    # @param type [Integer, Symbol] Type of channel to create (0: text, 2: voice, 4: category)
     # @param bitrate [Integer] the bitrate of this channel, if it will be a voice channel
     # @param user_limit [Integer] the user limit of this channel, if it will be a voice channel
     # @param permission_overwrites [Array<Hash>, Array<Overwrite>] permission overwrites for this channel
     # @param nsfw [true, false] whether this channel should be created as nsfw
     # @param reason [String] The reason the for the creation of this channel.
     # @return [Channel] the created channel.
-    # @raise [ArgumentError] if type is not 0 or 2
+    # @raise [ArgumentError] if type is not 0 (text), 2 (voice), or 4 (category)
     def create_channel(name, type = 0, bitrate: nil, user_limit: nil, permission_overwrites: [], nsfw: false, reason: nil)
-      raise ArgumentError, 'Channel type must be either 0 (text) or 2 (voice)!' unless [0, 2].include?(type)
+      type = Channel::TYPES[type] if type.is_a?(Symbol)
+      raise ArgumentError, 'Channel type must be either 0 (text), 2 (voice), or 4 (category)!' unless [0, 2, 4].include?(type)
       permission_overwrites.map! { |e| e.is_a?(Overwrite) ? e.to_hash : e }
       response = API::Server.create_channel(@bot.token, @id, name, type, bitrate, user_limit, permission_overwrites, nsfw, reason)
       Channel.new(JSON.parse(response), @bot)


### PR DESCRIPTION
Opening this to see if there's any other abstractions wanted.

- Implements Cats :cat: 
- Adds method for bulk setting permission overwrites
- Channel types can be specified by symbol when creating them

Todo:
- [ ] `Channel` needs the way it applies updates its data to behave like the other data classes. A bunch of the `#name=` methods etc, are broken in master right now. No further comments here.
- [ ] Update Specceroos
- [ ] Implement `locked_permissions` in `PATCH /guilds/{gid}/channels` for moving channels into a category to have Discord update its permission overwrites to match the parent cat. ~~**Update:** The API method doesn't work at all and will take a little head scratching to implement and abstract in a useful way.~~ API method fixed in 0be058b