### PR TITLE
Docs fixes

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'yard', '~> 0.8.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9.9'
   spec.add_development_dependency 'rspec', '~> 3.4.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
   spec.add_development_dependency 'rubocop', '0.49.1'

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -157,7 +157,7 @@ module Discordrb
     # @overload emoji(id)
     #   Return an emoji by its ID
     #   @param id [Integer, #resolve_id] The emoji's ID.
-    #   @return emoji [Emoji, nil] the emoji object. `nil` if the emoji was not found.
+    #   @return [Emoji, nil] the emoji object. `nil` if the emoji was not found.
     # @overload emoji
     #   The list of emoji the bot can use.
     #   @return [Array<Emoji>] the emoji available.

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -379,6 +379,8 @@ module Discordrb
     # @param file [File] The file that should be sent.
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
+    # @example Send a file from disk
+    #   bot.send_file(83281822225530880, File.open('rubytaco.png', 'r'))
     def send_file(channel, file, caption: nil, tts: false)
       channel = channel.resolve_id
       response = API::Channel.upload_file(token, channel, file, caption: caption, tts: tts)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -584,6 +584,7 @@ module Discordrb
       raise_event(HeartbeatEvent.new(self))
     end
 
+    # Makes the bot leave any groups with no recipients remaining
     def prune_empty_groups
       @channels.each_value do |channel|
         channel.leave_group if channel.group? && channel.recipients.empty?

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2124,7 +2124,7 @@ module Discordrb
     # @return [Array<Embed>] the embed objects contained in this message.
     attr_reader :embeds
 
-    # @return [Hash<String, Reaction>] the reaction objects attached to this message keyed by the name of the reaction
+    # @return [Hash<String => Reaction>] the reaction objects attached to this message keyed by the name of the reaction
     attr_reader :reactions
 
     # @return [true, false] whether the message used Text-To-Speech (TTS) or not.
@@ -2564,7 +2564,7 @@ module Discordrb
     # @return [Array<Role>] an array of all the roles created on this server.
     attr_reader :roles
 
-    # @return [Hash<Integer, Emoji>] a hash of all the emoji available on this server.
+    # @return [Hash<Integer => Emoji>] a hash of all the emoji available on this server.
     attr_reader :emoji
     alias_method :emojis, :emoji
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -201,6 +201,8 @@ module Discordrb
     # @param file [File] The file to send to the user
     # @param caption [String] The caption of the file being sent
     # @return [Message] the message sent to this user.
+    # @example Send a file from disk
+    #   user.send_file(File.open('rubytaco.png', 'r'))
     def send_file(file, caption = nil)
       pm.send_file(file, caption: caption)
     end
@@ -1430,6 +1432,8 @@ module Discordrb
     # @param file [File] The file to send. There's no clear size limit for this, you'll have to attempt it for yourself (most non-image files are fine, large images may fail to embed)
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
+    # @example Send a file from disk
+    #   channel.send_file(File.open('rubytaco.png', 'r'))
     def send_file(file, caption: nil, tts: false)
       @bot.send_file(@id, file, caption: caption, tts: tts)
     end

--- a/lib/discordrb/events/generic.rb
+++ b/lib/discordrb/events/generic.rb
@@ -19,7 +19,7 @@ module Discordrb::Events
   #  2. A single attribute, negated
   #  3. An array of attributes, not negated
   #  4. An array of attributes, not negated
-  # Note that it doesn't allow an array of negated attributes. For info on negation stuff, see {not!}
+  # Note that it doesn't allow an array of negated attributes. For info on negation stuff, see {::#not!}
   # @param attributes [Object, Array<Object>, Negated<Object>, Negated<Array<Object>>, nil] One or more attributes to
   #   compare to the to_check value.
   # @param to_check [Object] What to compare the attributes to.

--- a/lib/discordrb/events/guilds.rb
+++ b/lib/discordrb/events/guilds.rb
@@ -82,6 +82,7 @@ module Discordrb::Events
       process_emoji(data)
     end
 
+    # @!visibility private
     def process_emoji(data)
       @emoji = data['emojis'].map do |e|
         @server.emoji[e['id']]

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -113,6 +113,8 @@ module Discordrb::Events
     # @param file [File] The file to send to the channel
     # @param caption [String] The caption attached to the file
     # @return [Discordrb::Message] the message that was sent
+    # @example Send a file from disk
+    #   event.send_file(File.open('rubytaco.png', 'r'))
     def send_file(file, caption: nil)
       @message.channel.send_file(file, caption: caption)
     end

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -100,6 +100,7 @@ module Discordrb
       @invalid = false
     end
 
+    # Flags this session as suspended, so we know not to try and send heartbeats, etc. to the gateway until we've reconnected
     def suspend
       @suspended = true
     end
@@ -108,10 +109,12 @@ module Discordrb
       @suspended
     end
 
+    # Flags this session as no longer being suspended, so we can resume
     def resume
       @suspended = false
     end
 
+    # Flags this session as being invalid
     def invalidate
       @invalid = true
     end


### PR DESCRIPTION
- Add brief examples of uploading a file from a disk, as `File` seems to not be getting the point across
- Fixes some broken method link and invalid return tag in some docs
- Adds docs to some other undocumented methods, as listed by `yard stats --list-undoc` (some of which on `Session` - please check that I'm understanding them right)
- Upgrades to YARD 0.9.9, as the current version throws a bunch of old `::TRUE`, etc. constant warnings because they're deprecated
- There were two methods it seems using a `Hash` type signature inconsistently with the rest of the lib