### PR TITLE
Remove examples of client_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can make a simple bot like this:
 ```ruby
 require 'discordrb'
 
-bot = Discordrb::Bot.new token: '<token here>', client_id: 168123456789123456
+bot = Discordrb::Bot.new token: '<token here>'
 
 bot.message(with_text: 'Ping!') do |event|
   event.respond 'Pong!'

--- a/examples/commands.rb
+++ b/examples/commands.rb
@@ -4,7 +4,7 @@ require 'discordrb'
 
 # Here we instantiate a `CommandBot` instead of a regular `Bot`, which has the functionality to add commands using the
 # `command` method. We have to set a `prefix` here, which will be the character that triggers command execution.
-bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543, prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', prefix: '!'
 
 bot.command :user do |event|
   # Commands send whatever is returned from the block to the channel. This allows for compact commands like this,

--- a/examples/eval.rb
+++ b/examples/eval.rb
@@ -5,7 +5,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543, prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', prefix: '!'
 
 bot.command(:eval, help_available: false) do |event, *code|
   break unless event.user.id == 66237334693085184 # Replace number with your ID

--- a/examples/ping.rb
+++ b/examples/ping.rb
@@ -5,13 +5,13 @@ require 'discordrb'
 # This statement creates a bot with the specified token and application ID. After this line, you can add events to the
 # created bot, and eventually run it.
 #
-# If you don't yet have a token and application ID to put in here, you will need to create a bot account here:
+# If you don't yet have a token to put in here, you will need to create a bot account here:
 #   https://discordapp.com/developers/applications/me
 # If you're wondering about what redirect URIs and RPC origins, you can ignore those for now. If that doesn't satisfy
 # you, look here: https://github.com/meew0/discordrb/wiki/Redirect-URIs-and-RPC-origins
-# After creating the bot, simply copy the token (*not* the OAuth2 secret) and the client ID and put it into the
-# respective places.
-bot = Discordrb::Bot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543
+# After creating the bot, simply copy the token (*not* the OAuth2 secret) and put it into the
+# respective place.
+bot = Discordrb::Bot.new token: 'B0T.T0KEN.here'
 
 # Here we output the invite URL to the console so the bot account can be invited to the channel. This only has to be
 # done once, afterwards, you can remove this part if you want

--- a/examples/ping_with_respond_time.rb
+++ b/examples/ping_with_respond_time.rb
@@ -3,7 +3,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Bot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543
+bot = Discordrb::Bot.new token: 'B0T.T0KEN.here'
 
 bot.message(content: 'Ping!') do |event|
   # The `respond` method returns a `Message` object, which is stored in a variable `m`. The `edit` method is then called

--- a/examples/pm_send.rb
+++ b/examples/pm_send.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Bot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543
+bot = Discordrb::Bot.new token: 'B0T.T0KEN.here'
 
 # The `mention` event is called if the bot is *directly mentioned*, i.e. not using a role mention or @everyone/@here.
 bot.mention do |event|

--- a/examples/shutdown.rb
+++ b/examples/shutdown.rb
@@ -2,7 +2,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543, prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', prefix: '!'
 
 # Here we can see the `help_available` property used, which can determine whether a command shows up in the default
 # generated `help` command. It is true by default but it can be set to false to hide internal commands that only

--- a/examples/voice_send.rb
+++ b/examples/voice_send.rb
@@ -6,7 +6,7 @@
 
 require 'discordrb'
 
-bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', client_id: 160123456789876543, prefix: '!'
+bot = Discordrb::Commands::CommandBot.new token: 'B0T.T0KEN.here', prefix: '!'
 
 bot.command(:connect) do |event|
   # The `voice_channel` method returns the voice channel the user is currently in, or `nil` if the user is not in a

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -78,7 +78,8 @@ module Discordrb
     # @param token [String] The token that should be used to log in. If your bot is a bot account, you have to specify
     #   this. If you're logging in as a user, make sure to also set the account type to :user so discordrb doesn't think
     #   you're trying to log in as a bot.
-    # @param client_id [Integer] If you're logging in as a bot, the bot's client ID.
+    # @param client_id [Integer] If you're logging in as a bot, the bot's client ID. This is optional, and may be fetched
+    #   from the API by calling {Bot#bot_application} (see {Application}).
     # @param type [Symbol] This parameter lets you manually overwrite the account type. This needs to be set when
     #   logging in as a user, otherwise discordrb will treat you as a bot account. Valid values are `:user` and `:bot`.
     # @param name [String] Your bot's name. This will be sent to Discord with any API requests, who will use this to


### PR DESCRIPTION
This is a completely optional parameter that is currently only used to build OAuth2 bot invite URLs. It's an unnecessary extra step for beginners to the library, and the bot will cache the client ID from making an API request to build the invite URL if it isn't already cached from the bot initializer.

As discussed, this probably shouldn't be merged until right before the next release, as anyone following these updated examples, `Bot#invite_url` won't be built properly since `client_id` will be `nil`. Not a big deal either way though.