### PR TITLE
ensure_user when initializing a message with an uncached author

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2291,7 +2291,7 @@ module Discordrb
 
                     unless member
                       Discordrb::LOGGER.debug("Member with ID #{data['author']['id']} not cached (possibly left the server).")
-                      member = @bot.user(data['author']['id'].to_i)
+                      member = @bot.ensure_user(data['author'])
                     end
 
                     member

--- a/spec/data/message.json
+++ b/spec/data/message.json
@@ -1,0 +1,21 @@
+{
+    "attachments": [],
+    "tts": false,
+    "embeds": [],
+    "timestamp": "2017-09-21T19:53:15.684000+00:00",
+    "mention_everyone": false,
+    "id": "360513832470315009",
+    "pinned": false,
+    "edited_timestamp": null,
+    "author": {
+        "username": "Ghosty",
+        "discriminator": "8204",
+        "id": "97437477723193344",
+        "avatar": "c41f34685cd25cb4c2401f56fbdaedbc"
+    },
+    "mention_roles": [],
+    "content": "i have not been able to use my computer machine due to curriculum-assigned domal tasks",
+    "channel_id": "83281822225530880",
+    "mentions": [],
+    "type": 0
+}

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -67,6 +67,30 @@ module Discordrb
     end
   end
 
+  describe Message do
+    let(:server) { double('server') }
+    let(:channel) { double('channel', server: server) }
+    let(:token) { double('token') }
+    let(:bot) { double('bot', channel: channel, token: token) }
+
+    fixture :message_data, %i[message]
+    fixture_property :message_author, :message_data, ['author']
+
+    describe '#initialize' do
+      it 'caches an unavailable author' do
+        allow(server).to receive(:member)
+        allow(channel).to receive(:private?)
+        allow(channel).to receive(:text?)
+
+        # Bot will receive #ensure_user because the observed message author
+        # is not present in the server cache, which is possible
+        # (for example) if the author had left the server.
+        expect(bot).to receive(:ensure_user).with message_author
+        described_class.new(message_data, bot)
+      end
+    end
+  end
+
   describe Webhook do
     let(:token) { double('token') }
     let(:reason) { double('reason') }


### PR DESCRIPTION
In certain use cases like scraping long channel history, we may come across uncached users who have left the guild. We would make an API request here to resolve them, but a message author is always a full User object which we can cache with ensure_user instead of making a request to the API.

Also notably, this would cause exceptions on selfbots who cannot access `GET /users/{user.id}`

---
Todo:
- [x] Fix specs per Nekka's review