### PR TITLE
Implement a more useful way of sorting channels

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -16,13 +16,13 @@ module Discordrb::API::Channel
 
   # Update a channel's data
   # https://discordapp.com/developers/docs/resources/channel#modify-channel
-  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, reason = nil)
+  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, permission_overwrites, parent_id, reason = nil)
     Discordrb::API.request(
       :channels_cid,
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}",
-      { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw }.to_json,
+      { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw, permission_overwrites: permission_overwrites, parent_id: parent_id }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -97,17 +97,16 @@ module Discordrb::API::Server
   end
 
   # Update a channels position
-  # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel
-  def update_channel(token, server_id, channel_id, position, reason = nil)
+  # https://discordapp.com/developers/docs/resources/guild#modify-guild-channel-positions
+  def update_channel_positions(token, server_id, positions)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      { id: channel_id, position: position }.to_json,
+      positions.to_json,
       Authorization: token,
-      content_type: :json,
-      'X-Audit-Log-Reason': reason
+      content_type: :json
     )
   end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1375,27 +1375,67 @@ module Discordrb
     CHANNEL_MOVE_CONTEXT = 10
 
     # Sorts this channel to follow another channel.
-    # @param other [Channel, #resolve_id] The channel below which this channel should be sorted.
+    # @param other [Channel, #resolve_id, nil] The channel below which this channel should be sorted. If the given
+    #   channel is a category, this channel will be sorted at the top of that category. If it is `nil`, the channel will
+    #   be sorted at the top of the channel list.
     def sort_after(other)
-      other = @bot.channel(other)
-
-      # Position values in Discord channels are unique for a given channel type, but not unique over multiple types
-      raise ArgumentError, 'Can only sort a channel after a channel of the same type!' unless other.type == @type
       relevant_channels = @server.channels.select { |e| e.type == @type }
 
       # The channels need to be sorted by position so the indices are correct
       relevant_channels.sort_by!(&:position)
 
-      other_index = relevant_channels.index { |e| e.id == other.id }
+      other = @bot.channel(other) if other
+
+      if other && !other.category?
+        # We were given a concrete channel to sort after. Find its index
+        # Position values in Discord channels are unique for a given channel type, but not unique over multiple types
+        raise ArgumentError, 'Can only sort a channel after a channel of the same type!' unless other.type == @type
+
+        other_index = relevant_channels.index { |e| e.id == other.id }
+
+        # Whether the current channel is being moved up (true) or down (false)
+        move_up = (other.position < @position)
+
+        # Category to move into
+        destination_category_id = other.category ? other.category.id : nil
+      elsif other
+        # The given channel is a category, so the current channel should be sorted at the beginning of that category.
+        # First, find the category to sort into. (Simply the given channel)
+        category = other
+
+        # Now find the first channel that has a category with a position greater or equal to the category the current
+        # channel should be sorted into. This lets us decrement the index to find the last channel that is above the
+        # category to sort into.
+        first_channel_after_category = relevant_channels.index { |e| e.category && e.category.id == other.id }
+
+        if first_channel_after_category
+          # We found the channel; decrement the index
+          other_index = first_channel_after_category - 1
+          move_up = (relevant_channels[other_index].position < @position)
+        else
+          # There is no channel after the category, which means that the category to be sorted into is one of a bunch
+          # of empty categories at the bottom. Use the last channel's index.
+          other_index = relevant_channels.length - 1
+          move_up = false
+        end
+
+        destination_category_id = category.id
+      else
+        # The current channel should be sorted at the very top of the list -- set other_index to -1 (will get
+        # incremented to 0 later on)
+        other_index = -1
+        move_up = true
+        destination_category_id = nil
+      end
 
       # Argument for the final `update_channel_positions` API call
       move_argument = []
 
-      if other.position < @position
+      if move_up
         # The channel is being moved *up* so the current channel must be at the top, followed by the context channels.
         # As the current channel will be moved *after* the `other` channel, the index (of the `other` channel) must be
         # incremented by one.
-        move_argument << { id: @id, position: other_index + 1, parent_id: other.category ? other.category.id : nil }
+        move_argument << { id: @id, position: other_index + 1, parent_id: destination_category_id }
 
         # Provide Discord with following channels
         move_argument += process_channel_array(relevant_channels[(other_index + 1)..(other_index + CHANNEL_MOVE_CONTEXT + 1)])
@@ -1411,7 +1451,7 @@ module Discordrb
         move_argument += process_result
 
         # Now add the current channel
-        move_argument << { id: @id, position: other_index, parent_id: other.category ? other.category.id : nil }
+        move_argument << { id: @id, position: other_index, parent_id: destination_category_id }
       end
 
       API::Server.update_channel_positions(@bot.token, @server.id, move_argument)

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1378,7 +1378,9 @@ module Discordrb
     # @param other [Channel, #resolve_id, nil] The channel below which this channel should be sorted. If the given
     #   channel is a category, this channel will be sorted at the top of that category. If it is `nil`, the channel will
     #   be sorted at the top of the channel list.
-    def sort_after(other)
+    # @param lock_permissions [true, false] Whether the channel's permissions should be synced to the category's
+    #   permissions. Only applicable if the channel is sorted into another category.
+    def sort_after(other, lock_permissions = false)
       relevant_channels = @server.channels.select { |e| e.type == @type }
 
       # The channels need to be sorted by position so the indices are correct
@@ -1435,7 +1437,7 @@ module Discordrb
         # The channel is being moved *up* so the current channel must be at the top, followed by the context channels.
         # As the current channel will be moved *after* the `other` channel, the index (of the `other` channel) must be
         # incremented by one.
-        move_argument << { id: @id, position: other_index + 1, parent_id: destination_category_id }
+        move_argument << { id: @id, position: other_index + 1, parent_id: destination_category_id, lock_permissions: lock_permissions }
 
         # Provide Discord with following channels
         move_argument += process_channel_array(relevant_channels[(other_index + 1)..(other_index + CHANNEL_MOVE_CONTEXT + 1)])
@@ -1451,7 +1453,7 @@ module Discordrb
         move_argument += process_result
 
         # Now add the current channel
-        move_argument << { id: @id, position: other_index, parent_id: destination_category_id }
+        move_argument << { id: @id, position: other_index, parent_id: destination_category_id, lock_permissions: lock_permissions }
       end
 
       API::Server.update_channel_positions(@bot.token, @server.id, move_argument)


### PR DESCRIPTION
Depends on #415.

Adds a method `Channel#sort_after` that can be used to sort a channel after another in the list. Uses the same algorithm as Discord so it should be fairly reliable.