### PR TITLE
Remove `mentions` in API::Channel#send_message, Respondable tweaks

### DIFF
--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -68,13 +68,13 @@ module Discordrb::API::Channel
 
   # Send a message to a channel
   # https://discordapp.com/developers/docs/resources/channel#create-message
-  def create_message(token, channel_id, message, mentions = [], tts = false, embed = nil) # send message
+  def create_message(token, channel_id, message, tts = false, embed = nil) # send message
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages",
-      { content: message, mentions: mentions, tts: tts, embed: embed }.to_json,
+      { content: message, tts: tts, embed: embed }.to_json,
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -350,7 +350,7 @@ module Discordrb
       channel = channel.resolve_id
       debug("Sending message to #{channel} with content '#{content}'")
 
-      response = API::Channel.create_message(token, channel, content, [], tts, embed ? embed.to_hash : nil)
+      response = API::Channel.create_message(token, channel, content, tts, embed ? embed.to_hash : nil)
       Message.new(JSON.parse(response), self)
     end
 

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -12,9 +12,22 @@ module Discordrb::Events
     # Sends a message to the channel this message was sent in, right now. It is usually preferable to use {#<<} instead
     # because it avoids rate limiting problems
     # @param content [String] The message to send to the channel
+    # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
+    # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
     # @return [Discordrb::Message] the message that was sent
-    def send_message(content)
-      channel.send_message(content)
+    def send_message(content, tts = false, embed = nil)
+      channel.send_message(content, tts, embed)
+    end
+
+    # The same as {#send_message}, but yields a {Webhooks::Embed} for easy building of embedded content inside a block.
+    # @see Channel#send_embed
+    # @param message [String] The message that should be sent along with the embed. If this is the empty string, only the embed will be shown.
+    # @param embed [Discordrb::Webhooks::Embed, nil] The embed to start the building process with, or nil if one should be created anew.
+    # @yield [embed] Yields the embed to allow for easy building inside a block.
+    # @yieldparam embed [Discordrb::Webhooks::Embed] The embed from the parameters, or a new one.
+    # @return [Message] The resulting message.
+    def send_embed(message = '', embed = nil, &block)
+      channel.send_embed(message, embed, &block)
     end
 
     # Sends a temporary message to the channel this message was sent in, right now.
@@ -97,14 +110,6 @@ module Discordrb::Events
       @channel = message.channel
       @saved_message = ''
       @file = nil
-    end
-
-    # Sends a message to the channel this message was sent in, right now. It is usually preferable to use {#<<} instead
-    # because it avoids rate limiting problems
-    # @param content [String] The message to send to the channel
-    # @return [Discordrb::Message] the message that was sent
-    def send_message(content)
-      @message.channel.send_message(content)
     end
 
     # Sends file with a caption to the channel this message was sent in, right now.


### PR DESCRIPTION
- Removes `mentions` from `API::Channel#send_message`. Unsure where this came from, but Discord doesn't support sending this; it is just ignored, and we always sent a hard-coded empty array anyways in our abstraction.
- Removes `MessageEvent#send_message`. This was already included from `Respondable`, and was being overwritten.
- Adds support for `embed`s arguments in `Respondable#send_message`, and adds `Respondable#send_embed` forwarding to `Channel#send_embed`