### PR TITLE
fix Discordrb::Cache#server

### DIFF
--- a/lib/discordrb/cache.rb
+++ b/lib/discordrb/cache.rb
@@ -97,7 +97,7 @@ module Discordrb
       LOGGER.out("Resolving server #{id}")
       begin
         response = API::Server.resolve(token, id)
-      rescue RestClient::ResourceNotFound
+      rescue Discordrb::Errors::NoPermission
         return nil
       end
       server = Server.new(JSON.parse(response), self)


### PR DESCRIPTION
Change before
```ruby
bot = Discordrb::Bot.new(
		token: token,
		client_id: client_id)

p bot.server(1) # => Discordrb::Errors::NoPermission
```