### PR TITLE
Add `increment` parameter to `Bucket#rate_limited?`.

### DIFF
--- a/spec/rate_limiter_spec.rb
+++ b/spec/rate_limiter_spec.rb
@@ -36,6 +36,13 @@ describe Discordrb::Commands::Bucket do
       expect(b.rate_limited?(:a)).to be_truthy
     end
 
+    it 'should allow to be passed a custom increment' do
+      b = BUCKET.new(5, 5, nil)
+      expect(b.rate_limited?(:a, increment: 2)).to be_falsy
+      expect(b.rate_limited?(:a, increment: 2)).to be_falsy
+      expect(b.rate_limited?(:a, increment: 2)).to be_truthy
+    end
+
     it 'should not rate limit after the limit ran out' do
       b = BUCKET.new(2, 5, nil)
       expect(b.rate_limited?(:a)).to be_falsy


### PR DESCRIPTION
This adds the ability to increment the internal counter by an arbitrary
amount. This allows to eg properly rate-limit commands which can have
varying impact on other systems.

Note that there is a YARD warning regarding the doc string on line 40:
```
[warn]: @param tag has unknown parameter name: increment: 
    in file `lib/discordrb/commands/rate_limiter.rb' near line 42
```

However, the documentation is generated correctly. Changing `increment:` to `increment` in the docs silences the warning, but leads to YARD not picking up the default value.