### PR TITLE
Only check for matching events of the correct class in awaits

### DIFF
--- a/lib/discordrb/await.rb
+++ b/lib/discordrb/await.rb
@@ -41,7 +41,7 @@ module Discordrb
     # @return [Array] This await's key and whether or not it should be deleted. If there was no match, both are nil.
     def match(event)
       dummy_handler = EventContainer.handler_class(@type).new(@attributes, @bot)
-      return [nil, nil] unless dummy_handler.matches?(event)
+      return [nil, nil] unless event.instance_of?(@type) && dummy_handler.matches?(event)
 
       should_delete = nil
       should_delete = true if (@block && @block.call(event) != false) || !@block


### PR DESCRIPTION
When processing awaits, `#matches?` would incorrectly return true for *different* events that share a superclass, meaning some events would trigger awaits twice, or be triggered on different sibling events.

This checks up front, before processing the awaited event, that the event is an instance of the specific event class being awaited, ignoring inheritance.

Closes #422, #430