### PR TITLE
[WIP] Document metaprogrammed permissions methods

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'yard', '~> 0.8.7.6'
+  spec.add_development_dependency 'yard', '~> 0.9'
   spec.add_development_dependency 'rspec', '~> 3.4.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
   spec.add_development_dependency 'rubocop', '0.49.1'

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -3,45 +3,19 @@
 module Discordrb
   # List of permissions Discord uses
   class Permissions
-    # This hash maps bit positions to logical permissions.
-    # I'm not sure what the unlabeled bits are reserved for.
-    Flags = {
-      # Bit => Permission # Value
-      0 => :create_instant_invite, # 1
-      1 => :kick_members,          # 2
-      2 => :ban_members,           # 4
-      3 => :administrator,         # 8
-      4 => :manage_channels,       # 16
-      5 => :manage_server,         # 32
-      6 => :add_reactions,         # 64
-      7 => :view_audit_log,        # 128
-      # 8                          # 256
-      # 9                          # 512
-      10 => :read_messages,        # 1024
-      11 => :send_messages,        # 2048
-      12 => :send_tts_messages,    # 4096
-      13 => :manage_messages,      # 8192
-      14 => :embed_links,          # 16384
-      15 => :attach_files,         # 32768
-      16 => :read_message_history, # 65536
-      17 => :mention_everyone,     # 131072
-      18 => :use_external_emoji,   # 262144
-      # 19                         # 524288
-      20 => :connect,              # 1048576
-      21 => :speak,                # 2097152
-      22 => :mute_members,         # 4194304
-      23 => :deafen_members,       # 8388608
-      24 => :move_members,         # 16777216
-      25 => :use_voice_activity,   # 33554432
-      26 => :change_nickname,      # 67108864
-      27 => :manage_nicknames,     # 134217728
-      28 => :manage_roles,         # 268435456, also Manage Permissions
-      29 => :manage_webhooks,      # 536870912
-      30 => :manage_emojis         # 1073741824
-    }.freeze
+    # @!macro [attach] add_flag
+    #   @method can_$2=(value)
+    #     Sets whether this resource can `$2`
+    #     @param value [true, false]
+    # @!macro [attach] add_flag
+    #   @method $2
+    #     @return [true, false] whether this resouce can `$2`
+    def self.add_flag(position, flag)
+      @@flags ||= {}
+      @@flags[position] = flag
 
-    Flags.each do |position, flag|
       attr_reader flag
+
       define_method "can_#{flag}=" do |value|
         new_bits = @bits
         if value
@@ -54,6 +28,35 @@ module Discordrb
         init_vars
       end
     end
+
+    add_flag(0, :create_instant_invite)
+    add_flag(1, :kick_members)
+    add_flag(2, :ban_members)
+    add_flag(3, :administrator)
+    add_flag(4, :manage_channels)
+    add_flag(5, :manage_server)
+    add_flag(6, :add_reactions)
+    add_flag(7, :view_audit_log)
+    add_flag(10, :read_messages)
+    add_flag(11, :send_messages)
+    add_flag(12, :send_tts_messages)
+    add_flag(13, :manage_messages)
+    add_flag(14, :embed_links)
+    add_flag(15, :attach_files)
+    add_flag(16, :read_message_history)
+    add_flag(17, :mention_everyone)
+    add_flag(18, :use_external_emoji)
+    add_flag(20, :connect)
+    add_flag(21, :speak)
+    add_flag(22, :mute_members)
+    add_flag(23, :deafen_members)
+    add_flag(24, :move_members)
+    add_flag(25, :use_voice_activity)
+    add_flag(26, :change_nickname)
+    add_flag(27, :manage_nicknames)
+    add_flag(28, :manage_roles)
+    add_flag(29, :manage_webhooks)
+    add_flag(30, :manage_emojis)
 
     alias_method :can_administrate=, :can_administrator=
     alias_method :administrate, :administrator
@@ -69,7 +72,7 @@ module Discordrb
 
     # Initialize the instance variables based on the bitset.
     def init_vars
-      Flags.each do |position, flag|
+      @@flags.each do |position, flag|
         flag_set = ((@bits >> position) & 0x1) == 1
         instance_variable_set "@#{flag}", flag_set
       end
@@ -85,7 +88,7 @@ module Discordrb
     def self.bits(list)
       value = 0
 
-      Flags.each do |position, flag|
+      @@flags.each do |position, flag|
         value += 2**position if list.include? flag
       end
 


### PR DESCRIPTION
Opening this for now so it's visible, and maybe someone can pick up this cool YARD trick and use it in their own code. Because, it is pretty cool.

There's a whole series of methods missing from our documentation since the methods are generated at runtime - I'm talking about the `Permissions` and `PermissionsCalculator` `can_do_xyz` methods. However, YARD provides us with a vehicle to document such methods using a DSL-style class method with a `@macro [attach]` tag.

However, this really should incur a breaking change in removing the `Flags` constant, as we would define this table with these "DSL" methods, and it's not sane to have two of the same table laying around. This is necessary because this does not work (does not show up in documentation):
```rb
Flags.each do |position, flag|
  add_flag(position, flag)
end
```
because YARD does not *execute* code. YARD *can* parse the "top level" class method calls, observe that they are called, and run the docs macro(s) we attached to it.
```rb
# @!macro [attach] add_flag
#   @method can_$2=(value)
#     Sets whether this resource can `$2`
#     @param value [true, false]
def self.add_flag(position, flag)
end

add_flag(1, :kick_members)
add_flag(2, :ban_nekka)
```
So for those reasons, I've removed `Flags` and instead build `@@flags = {}` instead with calls to `add_flag`. We can expose `@@flags` publicly some other way if we want, `Permissions.flags`, (I doubt anyone uses the raw hash). Either way, it's worth it to get these methods "properly" in our documentation, as I don't know currently how you can even find out about these methods without reading the source code or asking. :smile: 

- [YARD @macro tag](http://www.rubydoc.info/gems/yard/file/docs/Tags.md#macro)
---
Todo:
- [ ] Macro for `PermissionsCalculator` methods
- [ ] Currently I'm copped on using a class var. Rubocop tells me to use an instance var, [but I don't think that will work well for our use case](https://carc.in/#/r/34l9). Is it worth disabling this cop (maybe just for this file) or is there another way I may not be thinking of? (Remember, there is no runtime)
- [ ] Update specs to use `Permissions.flags`
- [ ] Spec `add_flag`
- [ ] Remove YARD 0.9 commit (See #409)