### PR TITLE
Added the system channel to the server class

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -30,13 +30,13 @@ module Discordrb::API::Server
 
   # Update a server
   # https://discordapp.com/developers/docs/resources/guild#modify-guild
-  def update(token, server_id, name, region, icon, afk_channel_id, afk_timeout, reason = nil)
+  def update(token, server_id, name, region, icon, afk_channel_id, system_channel_id, afk_timeout, reason = nil)
     Discordrb::API.request(
       :guilds_sid,
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}",
-      { name: name, region: region, icon: icon, afk_channel_id: afk_channel_id, afk_timeout: afk_timeout }.to_json,
+      { name: name, region: region, icon: icon, afk_channel_id: afk_channel_id, system_channel_id: system_channel_id, afk_timeout: afk_timeout }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2992,7 +2992,7 @@ module Discordrb
 
     # Sets the server's system channel.
     # @param system_channel [Channel, nil] The new system channel, or `nil` should it be disabled.
-    def system_channel=(afk_channel)
+    def system_channel=(system_channel)
       update_server_data(system_channel_id: system_channel.resolve_id)
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2991,7 +2991,7 @@ module Discordrb
     end
 
     # Sets the server's system channel.
-    # @param system_channel [Channel, nil] The new system channel, or `nil` should it be disabled.
+    # @param system_channel [Channel, String, Integer, #resolve_id, nil] The new system channel, or `nil` should it be disabled.
     def system_channel=(system_channel)
       update_server_data(system_channel_id: system_channel.resolve_id)
     end
@@ -3047,7 +3047,7 @@ module Discordrb
       @bot.channel(@afk_channel_id) if @afk_channel_id
     end
 
-    # @return [Channel, nil] the system channel of this server, or nil if none is set
+    # @return [Channel, nil] the system channel (used for automatic welcome messages) of a server, or nil if none is set
     def system_channel
       @bot.channel(@system_channel_id) if @system_channel_id
     end

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2990,6 +2990,12 @@ module Discordrb
       update_server_data(afk_channel_id: afk_channel.resolve_id)
     end
 
+    # Sets the server's system channel.
+    # @param system_channel [Channel, nil] The new system channel, or `nil` should it be disabled.
+    def system_channel=(afk_channel)
+      update_server_data(system_channel_id: system_channel.resolve_id)
+    end
+
     # Sets the amount of time after which a user gets moved into the AFK channel.
     # @param afk_timeout [Integer] The AFK timeout, in seconds.
     def afk_timeout=(afk_timeout)
@@ -3041,6 +3047,11 @@ module Discordrb
       @bot.channel(@afk_channel_id) if @afk_channel_id
     end
 
+    # @return [Channel, nil] the system channel of this server, or nil if none is set
+    def system_channel
+      @bot.channel(@system_channel_id) if @system_channel_id
+    end
+
     # Updates the cached data with new data
     # @note For internal use only
     # @!visibility private
@@ -3055,6 +3066,8 @@ module Discordrb
       @afk_channel_id = afk_channel_id.nil? ? nil : afk_channel_id.resolve_id
       embed_channel_id = new_data[:embed_channel_id] || new_data['embed_channel_id'] || @embed_channel
       @embed_channel_id = embed_channel_id.nil? ? nil : embed_channel_id.resolve_id
+      system_channel_id = new_data[:system_channel_id] || new_data['system_channel_id'] || @system_channel
+      @system_channel_id = system_channel_id.nil? ? nil : system_channel_id.resolve_id
 
       @embed = new_data[:embed_enabled] || new_data['embed_enabled'] || @embed
       @verification_level = %i[none low medium high very_high][new_data['verification_level']] || @verification_level
@@ -3088,7 +3101,7 @@ module Discordrb
 
     # The inspect method is overwritten to give more useful output
     def inspect
-      "<Server name=#{@name} id=#{@id} large=#{@large} region=#{@region} owner=#{@owner} afk_channel_id=#{@afk_channel_id} afk_timeout=#{@afk_timeout}>"
+      "<Server name=#{@name} id=#{@id} large=#{@large} region=#{@region} owner=#{@owner} afk_channel_id=#{@afk_channel_id} system_channel_id=#{@system_channel_id} afk_timeout=#{@afk_timeout}>"
     end
 
     private
@@ -3099,6 +3112,7 @@ module Discordrb
                                                new_data[:region] || @region_id,
                                                new_data[:icon_id] || @icon_id,
                                                new_data[:afk_channel_id] || @afk_channel_id,
+                                               new_data[:system_channel_id] || @system_channel_id,
                                                new_data[:afk_timeout] || @afk_timeout))
       update_data(response)
     end


### PR DESCRIPTION
It follows the same logic as the AFK channel, as in it's a server-side
change instead of a channel property

Below is a code block of the method tested with the built-in console:

```ruby
2.4.1 :002 > $bsuki = Discordrb::Commands::CommandBot.new(
2.4.1 :003 >     token: 'redacted'
2.4.1 :004?>   )
<CommandBot object gibberish>
2.4.1 :005 > $bsuki.server(369241481095020544).system_channel
 => <Channel name=redacted id=369241481095020546 topic="redacted" type=0 position=1 server=#<Discordrb::Server:0x00000002c553f8>> 
2.4.1 :006 > $bsuki.server(327235419865481216).system_channel.id
 => 384058316395118596 
2.4.1 :007 > $bsuki.server(327235419865481216).system_channel=384058316395118596
 => 384058316395118596 
2.4.1 :008 > $bsuki.server(327235419865481216).system_channel.id
 => 384058316395118596 
```
Depends on #391 