### PR TITLE
Fix bulk delete with messages older than 2 weeks.

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -1797,7 +1797,7 @@ module Discordrb
         message = "Attempted to bulk_delete message #{e} which is too old (min = #{min_snowflake})"
         raise ArgumentError, message if strict
         Discordrb::LOGGER.warn(message)
-        false
+        true
       end
 
       API::Channel.bulk_delete_messages(@bot.token, @id, ids)

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -28,6 +28,18 @@ module Discordrb
         messages = [1, 2, 3]
         expect { channel.delete_messages(messages, true) }.to raise_error(ArgumentError)
       end
+
+      it 'should remove old messages in non-strict mode' do
+        allow(IDObject).to receive(:synthesise).and_return(4)
+        messages = [1, 2, 3, 4]
+
+        # Suppresses some noisy WARN logging from specs output
+        allow(LOGGER).to receive(:warn)
+        allow(API::Channel).to receive(:bulk_delete_messages)
+
+        channel.delete_messages(messages)
+        expect(messages).to eq [4]
+      end
     end
 
     describe '#nsfw=' do


### PR DESCRIPTION
In the 'reject!' block in bulk_delete, return true instead of false to properly reject messages that are too old. I found this while adding a pruning command to my own bot, where I've been running a patch on top of Discord.rb - when the block returns false, it keeps the older messages and the API throws a 401 when submitted if the list of messages has anything too old. This was particularly problematic when using Channel#prune on a server with not much traffic. Hope this helps!