### PR TITLE
Doc typo fix

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -882,7 +882,7 @@ module Discordrb
     # @return [true, false] whether or not this role should be displayed separately from other users
     attr_reader :hoist
 
-    # @return [true, false] whether or not this role is managed by a integration or bot
+    # @return [true, false] whether or not this role is managed by an integration or bot
     attr_reader :managed
     alias_method :managed?, :managed
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -882,7 +882,7 @@ module Discordrb
     # @return [true, false] whether or not this role should be displayed separately from other users
     attr_reader :hoist
 
-    # @return [true, false] whether or not this role is managed by an integration or bot
+    # @return [true, false] whether or not this role is managed by an integration or a bot
     attr_reader :managed
     alias_method :managed?, :managed
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2716,7 +2716,7 @@ module Discordrb
     alias_method :widget?, :embed_enabled?
     alias_method :embed?, :embed_enabled?
 
-    # @return [Channel, nil] the channel the server embed will make a invite for.
+    # @return [Channel, nil] the channel the server embed will make an invite for.
     def embed_channel
       update_data if @embed_enabled.nil?
       @bot.channel(@embed_channel_id) if @embed_channel_id


### PR DESCRIPTION
“A” versus “An” (http://www.everythingenglishblog.com/?p=541)

“A” and “an” are indefinite articles used in the English language, whereas “the” is the only definite article used in the English language. To learn about proper overall article usage, see the blog post entitled Articles in English: “The,” “A,” and “An.”

As a brief recap of indefinite article use in English, you use “a” or “an” with a noun when referring to a member of a group or class. However, many people are slightly confused about when to use “a” and when to use “an.” An often repeated guideline is to use “a” when the word that follows starts with a consonant and to use “an” when word that follows starts with a vowel. Examples include “a book,” “an old book,” “an elephant,” and “a gray elephant.” Although this guideline will help you in most instances, it is not entirely true and will cause problems in some unique situations.

The actual rule governing the use of “a” versus “an” is related to the sound made by the first letter in the following word. More specifically, if the first letter of the following word makes a consonant sound, you should use “a;” in contrast, if the first letter of the following word is silent and/or makes a vowel sound, you should use “an.” This rule clearly still works for our previous examples, i.e., “a book” and “an elephant.” In addition, it also helps to clarify more difficult situations.

For example, let’s consider the word “hour.” It starts with an “h,” which is a consonant. However, the “h” in “hour” is silent; therefore, the first sound from this word is a vowel sound. Hence, a grammatically correct sentence would refer to “an hour,” not “a hour.” Yet, in other “h” words, the “h” or consonant sound is made, thereby requiring the use of “a.” Examples include “a history book” and “a hotdog.”

Also consider words starting with “u.” Some such words make a “y” or consonant sound (e.g., unicorn, unique, and ukulele); in such instances, you should use the article “a” (e.g., a unicorn, a unique store, and a ukulele). Others make a “u” vowel sound (e.g., umbrella, ugly, and uprising); in such instances, you should use the article “an” (e.g., an umbrella, an ugly dog, and an uprising).

Therefore, when you question whether you should use “a” or “an” in your writing endeavors, look at the word immediately following the article. Better yet, say the word aloud. If this word starts with a consonant sound, use “a.” If it starts with a vowel sound, use “an.”
  