### PR TITLE
Adds the ability to change a role's position

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -254,6 +254,20 @@ module Discordrb::API::Server
     )
   end
 
+  # Update role positions
+  # https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions
+  def update_role_positions(token, server_id, roles)
+    Discordrb::API.request(
+      :guilds_sid_roles,
+      server_id,
+      :patch,
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/roles",
+      roles.to_json,
+      Authorization: token,
+      content_type: :json
+    )
+  end
+
   # Delete a role
   # https://discordapp.com/developers/docs/resources/guild#delete-guild-role
   def delete_role(token, server_id, role_id, reason = nil)

--- a/spec/data/role.json
+++ b/spec/data/role.json
@@ -1,0 +1,10 @@
+{
+  "hoist": false,
+  "name": "crystal",
+  "mentionable": false,
+  "color": 0,
+  "position": 39,
+  "id": "240172879361212416",
+  "managed": false,
+  "permissions": 103809088
+}

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -91,6 +91,48 @@ module Discordrb
     end
   end
 
+  describe Role do
+    let(:server) { double('server', id: double) }
+    let(:bot) { double('bot', token: double) }
+
+    subject(:role) do
+      described_class.new(role_data, bot, server)
+    end
+
+    fixture :role_data, %i[role]
+
+    describe '#sort_above' do
+      context 'when other is nil' do
+        it 'sorts the role to position 1' do
+          allow(server).to receive(:update_role_positions)
+          allow(server).to receive(:roles).and_return [
+            double(id: 0, position: 0),
+            double(id: 1, position: 1)
+          ]
+
+          new_position = role.sort_above
+          expect(new_position).to eq 1
+        end
+      end
+
+      context 'when other is given' do
+        it 'sorts above other' do
+          other = double(id: 1, position: 1, resolve_id: 1)
+          allow(server).to receive(:update_role_positions)
+          allow(server).to receive(:role).and_return other
+          allow(server).to receive(:roles).and_return [
+            double(id: 0, position: 0),
+            other,
+            double(id: 2, position: 2)
+          ]
+
+          new_position = role.sort_above(other)
+          expect(new_position).to eq 2
+        end
+      end
+    end
+  end
+
   describe Webhook do
     let(:token) { double('token') }
     let(:reason) { double('reason') }


### PR DESCRIPTION
Provides the missing API method **Modify Guild Role Positions** identified in #309.

The role's position is modified by specifying another role to place it above in the list. If no other role is provided, it is moved to the bottom of the list, above the `@everyone` role.