### PR TITLE
Adds methods for modifying the command bot's allowed channel list

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -333,6 +333,30 @@ module Discordrb::Commands
       [@permissions[:users][user.id] || 0, determined_level].max >= level
     end
 
+    # @see CommandBot#update_channels
+    def channels=(channels)
+      update_channels(channels)
+    end
+
+    # Update the list of channels the bot accepts commands from.
+    # @param channels [Array<String, Integer, Channel>] The channels this command bot accepts commands on.
+    def update_channels(channels = [])
+      @attributes[:channels] = Array(channels)
+    end
+
+    # Add a channel to the list of channels the bot accepts commands from.
+    # @param channel [String, Integer, Channel] The channel name, integer ID, or `Channel` object to be added
+    def add_channel(channel)
+      return if @attributes[:channels].find { |c| channel.resolve_id == c.resolve_id }
+      @attributes[:channels] << channel
+    end
+
+    # Remove a channel from the list of channels the bot accepts commands from.
+    # @param channel [String, Integer, Channel] The channel name, integer ID, or `Channel` object to be removed
+    def remove_channel(channel)
+      @attributes[:channels].delete_if { |c| channel.resolve_id == c.resolve_id }
+    end
+
     private
 
     # Internal handler for MESSAGE_CREATE that is overwritten to allow for command handling
@@ -404,14 +428,9 @@ module Discordrb::Commands
     def channels?(channel, channels)
       return true if channels.nil? || channels.empty?
       channels.any? do |c|
-        if c.is_a? String
-          # Make sure to remove the "#" from channel names in case it was specified
-          c.delete('#') == channel.name
-        elsif c.is_a? Integer
-          c == channel.id
-        else
-          c == channel
-        end
+        # if c is string, make sure to remove the "#" from channel names in case it was specified
+        return true if c.is_a?(String) && c.delete('#') == channel.name
+        c.resolve_id == channel.resolve_id
       end
     end
 

--- a/spec/commands_spec.rb
+++ b/spec/commands_spec.rb
@@ -1,47 +1,305 @@
 require 'discordrb'
 
-describe Discordrb::Commands do
-  describe Discordrb::Commands::CommandBot do
-    def command_event_double
-      event = double('event')
+describe Discordrb::Commands::CommandBot, order: :defined do
+  SIMPLE_RESPONSE = 'hi'.freeze
+  TEST_CHANNELS = [
+    1,
+    2,
+    '3',
+    'channel-four',
+    '#channel-five'
+  ].freeze
+
+  let(:text_channel_data) { load_data_file(:text_channel) }
+  let(:default_channel_id) { 123 }
+  let(:default_channel_name) { 'test-channel' }
+  let(:user_id) { 321 }
+  let(:test_channels) { TEST_CHANNELS }
+  let(:first_channel) { test_channels[0] }
+  let(:second_channel) { test_channels[1] }
+  let(:third_channel) { test_channels[2] }
+  let(:fourth_channel) { test_channels[3] }
+  let(:fifth_channel) { test_channels[4] }
+  let(:sixth_channel) do
+    bot = double('bot')
+    allow(bot).to receive(:token) { 'fake token' }
+    Discordrb::Channel.new(text_channel_data, bot, double('server'))
+  end
+
+  def command_event_double
+    double('event').tap do |event|
       allow(event).to receive :command=
       allow(event).to receive(:drain_into) { |e| e }
-
-      event
+      allow(event).to receive(:server)
+      allow(event).to receive(:channel)
     end
+  end
 
-    context 'no defined commands' do
-      bot = Discordrb::Commands::CommandBot.new token: '', help_available: false
-
-      it 'should successfully trigger the command' do
-        event = double
-
-        bot.execute_command(:test, event, [], false, false)
-      end
-
-      it 'should not send anything to the channel' do
-        event = spy
-
-        bot.execute_command(:test, event, [], false, false)
-
-        expect(spy).to_not have_received :respond
+  def append_author_to_double(event)
+    allow(event).to receive(:author) do
+      double('member').tap do |member|
+        allow(member).to receive(:id) { user_id }
+        allow(member).to receive(:permission?) { true }
+        allow(member).to receive(:webhook?) { false }
       end
     end
+  end
 
-    context 'single command' do
-      bot = Discordrb::Commands::CommandBot.new token: '', help_available: false
+  def append_bot_to_double(event)
+    allow(event).to receive(:bot) do
+      double('bot').tap do |bot|
+        allow(bot).to receive(:token) { 'fake token' }
+        allow(bot).to receive(:rate_limited?) { false }
+        allow(bot).to receive(:attributes) { {} }
+      end
+    end
+  end
 
-      RESPONSE = 'hi'.freeze
+  def append_channel_to_double(event, channel_id, **kwargs)
+    data = text_channel_data.dup.merge kwargs
+    data['id'] = channel_id
+    data['name'] = kwargs.fetch(:name) { default_channel_name }
+    channel = Discordrb::Channel.new(data, event.bot, double('server'))
+    allow(event).to receive(:channel) { channel }
+  end
 
-      bot.command :name do
-        RESPONSE
+  def command_event_double_for_channel(channel_id = default_channel_id, **kwargs)
+    command_event_double.tap do |event|
+      append_author_to_double(event)
+      append_bot_to_double(event)
+      append_channel_to_double(event, channel_id, kwargs)
+    end
+  end
+
+  def command_event_double_with_channel(channel)
+    command_event_double.tap do |event|
+      append_author_to_double(event)
+      append_bot_to_double(event)
+      allow(event).to receive(:channel) { channel }
+    end
+  end
+
+  context 'no defined commands' do
+    bot = Discordrb::Commands::CommandBot.new token: '', help_available: false
+
+    it 'should successfully trigger the command' do
+      event = double
+
+      bot.execute_command(:test, event, [], false, false)
+    end
+
+    it 'should not send anything to the channel' do
+      event = spy
+
+      bot.execute_command(:test, event, [], false, false)
+
+      expect(spy).to_not have_received :respond
+    end
+  end
+
+  context 'single command' do
+    bot = Discordrb::Commands::CommandBot.new token: '', help_available: false
+
+    bot.command :name do
+      SIMPLE_RESPONSE
+    end
+
+    context 'regular user' do
+      it 'should return the response' do
+        result = bot.execute_command(:name, command_event_double, [], false, false)
+
+        expect(result).to eq SIMPLE_RESPONSE
+      end
+    end
+  end
+
+  describe '#execute_command', order: :defined do
+    context 'with channel filter', order: :defined do
+      context 'when list is not initialized in bot parameters', order: :defined do
+        bot = Discordrb::Commands::CommandBot.new(token: '', help_available: false)
+
+        bot.command :name do
+          SIMPLE_RESPONSE
+        end
+
+        it 'has no channels' do
+          expect(bot.attributes[:channels]).to be_empty
+        end
+
+        it 'responds in any channel when no channel list is provided' do
+          test_channels.each do |channel|
+            plain_event = command_event_double_for_channel(channel)
+            result = bot.execute_command(:name, plain_event, [])
+            expect(result).to eq SIMPLE_RESPONSE
+          end
+        end
+
+        it 'can have channels added' do
+          bot.add_channel(first_channel)
+          expect(bot.attributes[:channels]).to contain_exactly(first_channel)
+        end
+
+        it 'responds only in added channels' do
+          plain_event1 = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, plain_event1, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'does not have channels that were not added' do
+          expect(bot.attributes[:channels]).not_to include(second_channel, third_channel)
+        end
+
+        it 'does not respond in channels not added' do
+          plain_event2 = command_event_double_for_channel(second_channel)
+          result = bot.execute_command(:name, plain_event2, [])
+          expect(result).to be_nil
+
+          plain_event3 = command_event_double_for_channel(third_channel)
+          result = bot.execute_command(:name, plain_event3, [])
+          expect(result).to be_nil
+        end
       end
 
-      context 'regular user' do
-        it 'should return the response' do
-          result = bot.execute_command(:name, command_event_double, [], false, false)
+      context 'when list is initialized in bot parameters', order: :defined do
+        bot = Discordrb::Commands::CommandBot.new(token: '', help_available: false, channels: [TEST_CHANNELS[0]])
 
-          expect(result).to eq RESPONSE
+        bot.command :name do
+          SIMPLE_RESPONSE
+        end
+
+        it 'has the initial channels' do
+          expect(bot.attributes[:channels]).to contain_exactly(first_channel)
+        end
+
+        it 'responds in listed channels' do
+          event_listed = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, event_listed, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'does not respond in unlisted channels' do
+          event_unlisted = command_event_double_for_channel(second_channel)
+          result = bot.execute_command(:name, event_unlisted, [])
+          expect(result).to be_nil
+        end
+
+        it 'has both initial and added channels' do
+          bot.add_channel(second_channel)
+          expect(bot.attributes[:channels]).to contain_exactly(first_channel, second_channel)
+        end
+
+        it 'responds in all added channels' do
+          event_listed = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, event_listed, [])
+          expect(result).to eq SIMPLE_RESPONSE
+
+          event_added = command_event_double_for_channel(second_channel)
+          result = bot.execute_command(:name, event_added, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'removes channels' do
+          bot.remove_channel(first_channel)
+          expect(bot.attributes[:channels]).to contain_exactly(second_channel)
+        end
+
+        it 'does not respond in removed channels' do
+          event_removed = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, event_removed, [])
+          expect(result).to be_nil
+        end
+
+        it 'responds in all channels when the last channel is removed' do
+          bot.remove_channel(second_channel)
+
+          test_channels.each do |channel|
+            plain_event = command_event_double_for_channel(channel)
+            result = bot.execute_command(:name, plain_event, [])
+            expect(result).to eq SIMPLE_RESPONSE
+          end
+        end
+      end
+
+      context 'listed as a channel name', order: :defined do
+        bot = Discordrb::Commands::CommandBot.new(token: '', help_available: false)
+
+        bot.command :name do
+          SIMPLE_RESPONSE
+        end
+
+        it 'allows adding a channel by name' do
+          bot.add_channel(fourth_channel)
+          expect(bot.attributes[:channels]).to contain_exactly(fourth_channel)
+        end
+
+        it 'responds when channel name is used' do
+          event = command_event_double_for_channel(name: fourth_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'does not modify the channel list while responding to a channel name' do
+          expect(bot.attributes[:channels]).to contain_exactly(fourth_channel)
+        end
+
+        it 'does not respond for unlisted channels using channel name' do
+          event = command_event_double_for_channel(name: fifth_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to be_nil
+        end
+      end
+
+      context 'listed as an object', order: :defined do
+        bot = Discordrb::Commands::CommandBot.new(token: '', help_available: false)
+
+        bot.command :name do
+          SIMPLE_RESPONSE
+        end
+
+        it 'allows adding a channel object' do
+          bot.add_channel(sixth_channel)
+          expect(bot.attributes[:channels]).to contain_exactly(sixth_channel)
+        end
+
+        it 'responds when channel objects are used' do
+          event = command_event_double_with_channel(sixth_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'does not modify the list while respond to a channel object' do
+          expect(bot.attributes[:channels]).to contain_exactly(sixth_channel)
+        end
+
+        it 'does not respond in unlisted channels' do
+          event = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to be_nil
+        end
+      end
+
+      context 'command_bot#channels=', order: :defined do
+        bot = Discordrb::Commands::CommandBot.new(token: '', help_available: false, channels: [TEST_CHANNELS[0], TEST_CHANNELS[1]])
+
+        bot.command :name do
+          SIMPLE_RESPONSE
+        end
+
+        it 'new channels should replace old channels' do
+          bot.channels = [third_channel, sixth_channel]
+          expect(bot.attributes[:channels]).to contain_exactly(third_channel, sixth_channel)
+        end
+
+        it 'responds only in the new channels' do
+          event = command_event_double_for_channel(third_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to eq SIMPLE_RESPONSE
+        end
+
+        it 'does not respond in old channels' do
+          event = command_event_double_for_channel(first_channel)
+          result = bot.execute_command(:name, event, [])
+          expect(result).to be_nil
         end
       end
     end


### PR DESCRIPTION
Adding spec to test the bot for observing the channels whitelist.  Also including a few functions to simplify the functionality for adding/removing channels to the whitelist.