### PR TITLE
Server-Member caching bug fix

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2684,7 +2684,7 @@ module Discordrb
       return nil unless request
 
       member = @bot.member(self, id)
-      @members[id] = member
+      @members[id] = member unless member.nil?
     rescue
       nil
     end


### PR DESCRIPTION
When checking for any non-existing Discord user ID on a server, member(server_or_id, user_id) in cache.rb will attempt to resolve user and will receive a nil object when the user is not found.

That nil object ends up in the cache raising errors.

This might resolve the issues presented in issues #412 and #377 when attempting to resolve a non-existing user on a server.