### PR TITLE
Fix Channel#property= setter methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /.idea/
 .DS_Store
 *.gem
+**.sw*

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -16,13 +16,15 @@ module Discordrb::API::Channel
 
   # Update a channel's data
   # https://discordapp.com/developers/docs/resources/channel#modify-channel
-  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, permission_overwrites, parent_id, reason = nil)
+  def update(token, channel_id, name, topic, position, bitrate, user_limit, nsfw, permission_overwrites = nil, parent_id = nil, reason = nil)
+    data = { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw, parent_id: parent_id }
+    data[:permission_overwrites] = permission_overwrites unless permission_overwrites.nil?
     Discordrb::API.request(
       :channels_cid,
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}",
-      { name: name, position: position, topic: topic, bitrate: bitrate, user_limit: user_limit, nsfw: nsfw, permission_overwrites: permission_overwrites, parent_id: parent_id }.to_json,
+      data.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -114,5 +114,11 @@ module Discordrb
 
       init_vars
     end
+
+    # Comparison based on permission bits
+    def ==(other)
+      false unless other.is_a? Discordrb::Permissions
+      bits == other.bits
+    end
   end
 end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -28,6 +28,21 @@ module Discordrb
         expect(channel.__send__(property_name)).to eq(test_value)
       end
 
+      context 'when modifying a property' do
+        it 'should send an API call' do
+          expect(API).to receive(:request).with(:channels_cid,
+                                                data['id'].to_i,
+                                                :patch,
+                                                instance_of(String),
+                                                instance_of(String),
+                                                instance_of(Hash)) do
+            data[property_name.to_s] = set_value
+            data.to_json
+          end
+          channel.__send__("#{property_name}=", test_value)
+        end
+      end
+
       context 'when the API raises an error' do
         it 'should not change the cached value' do
           allow(channel).to receive(:update_channel_data).and_raise(Discordrb::Errors::NoPermission)
@@ -90,12 +105,12 @@ module Discordrb
         let(:topic) { 'test' }
 
         it 'should not send permissions_overwrites in the API call' do
-          expect(API).to receive(:request).with(:channels_cid,
-                                                kind_of(Numeric),
-                                                :patch,
-                                                instance_of(String),
-                                                instance_of(String),
-                                                instance_of(Hash)) do |*args|
+          allow(API).to receive(:request).with(:channels_cid,
+                                               data['id'].to_i,
+                                               :patch,
+                                               instance_of(String),
+                                               instance_of(String),
+                                               instance_of(Hash)) do |*args|
             json = JSON.parse(args[4], symbolize_names: true)
             expect(json).to_not have_key(:permission_overwrites)
             data['topic'] = topic

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -88,7 +88,8 @@ module Discordrb
 
       context 'when permissions_overwrites are not set' do
         let(:topic) { 'test' }
-        before do
+
+        it 'should not send permissions_overwrites in the API call' do
           expect(API).to receive(:request).with(:channels_cid,
                                                 kind_of(Numeric),
                                                 :patch,
@@ -100,9 +101,6 @@ module Discordrb
             data['topic'] = topic
             data.to_json
           end
-        end
-
-        it 'should not send permissions_overwrites in the API call' do
           subject.topic = topic
         end
       end


### PR DESCRIPTION
Fixes for both the setters not updating Channel properties and the
permission issue that arrises with the channel update API when
permissions_overwrites is sent with any of the properties that require
less privilege than overwriting permissions.