### PR TITLE
Bot#parse_mention returns an Emoji with available data

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -440,8 +440,8 @@ module Discordrb
 
         # Return nil if no role is found
         nil
-      elsif /<a?:(\w+):(?<id>\d+)>/ =~ mention
-        emoji(id)
+      elsif /<(?<animated>a)?:(?<name>\w+):(?<id>\d+)>/ =~ mention
+        emoji(id) || Emoji.new({'animated' => !animated.nil?, 'name' => name, 'id' => id}, self, nil)
       end
     end
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2426,7 +2426,7 @@ module Discordrb
     # @return [Array<String>] the emoji mentions found in the message
     def scan_for_emoji
       emoji = @content.split
-      emoji = emoji.grep(/<:(?<name>\w+):(?<id>\d+)>?/)
+      emoji = emoji.grep(/<(?<animated>a)?:(?<name>\w+):(?<id>\d+)>?/)
       emoji
     end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -36,6 +36,17 @@ module Discordrb
       expect(bot.server(server_id).emoji.size).to eq(2)
     end
 
+    describe '#parse_mention' do
+      context 'with an uncached emoji' do
+        it 'returns an emoji with the available data' do
+          allow(bot).to receive(:emoji)
+          string = '<a:foo:123>'
+          emoji = bot.parse_mention(string)
+          expect([emoji.name, emoji.id, emoji.animated]).to eq ['foo', 123, true]
+        end
+      end
+    end
+
     describe '#handle_dispatch' do
       it 'handles GUILD_EMOJIS_UPDATE' do
         type = :GUILD_EMOJIS_UPDATE


### PR DESCRIPTION
This fixes cases where a message is parsed for mentions with emoji that the bot does not have access to, and thus won't have cached, so `Bot#parse_mention` just returns `nil` on the cache miss. The emoji markdown itself still contains data we can return to the user (name, ID, whether its animated), we just won't know where it came from.

Also updates `Message#scan_for_emoji` to detect animated emoji.

I don't know if this is the best way to do this, but I really don't want to mess with `Emoji#initialize`, like some kind of hacky overload, or rearranging the arguments.