### PR TITLE
Adding RestClient::Utils patch for Ruby versions >=2.5 on Windows

### DIFF
--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -7,7 +7,7 @@ require 'discordrb/logger'
 
 # This fix in particular addresses an issue within RestClient, confirmed
 # in RestClient 2.0.2 but only within the Discordrb environment.
-if Gem::Verision.new(RUBY_VERSION) >= Gem::Version.new('2.5') && ENV['OS'] == 'Windows_NT'
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5') && ENV['OS'] == 'Windows_NT'
   require 'rest-client/utils'
 end
 

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -4,6 +4,7 @@ require 'discordrb/version'
 require 'discordrb/bot'
 require 'discordrb/commands/command_bot'
 require 'discordrb/logger'
+require 'rest-client/utils'
 
 # All discordrb functionality, to be extended by other files
 module Discordrb

--- a/lib/discordrb.rb
+++ b/lib/discordrb.rb
@@ -4,7 +4,12 @@ require 'discordrb/version'
 require 'discordrb/bot'
 require 'discordrb/commands/command_bot'
 require 'discordrb/logger'
-require 'rest-client/utils'
+
+# This fix in particular addresses an issue within RestClient, confirmed
+# in RestClient 2.0.2 but only within the Discordrb environment.
+if Gem::Verision.new(RUBY_VERSION) >= Gem::Version.new('2.5') && ENV['OS'] == 'Windows_NT'
+  require 'rest-client/utils'
+end
 
 # All discordrb functionality, to be extended by other files
 module Discordrb

--- a/lib/rest-client/utils.rb
+++ b/lib/rest-client/utils.rb
@@ -1,31 +1,30 @@
-# @note In Ruby versions greater than 2.4 on Windows, Discordrb's 
-# environment does not play nicely with the use of enumerators in
-# this specific function. The exact reason is unknown, but changing the use of
-# `Enumerator#next` into iteration via `Array#shift` prevents a silent crash.
+# RestClient module, RestClient#get being the main scope of the issue
+module RestClient
+  # Utils contains the helper method that causes issues
+  module Utils
+    # @note In Ruby versions greater than 2.4 on Windows, Discordrb's 
+    # environment does not play nicely with the use of enumerators in
+    # this specific function. The exact reason is unknown, but changing the use of
+    # `Enumerator#next` into iteration via `Array#shift` prevents a silent crash.
+    def self.cgi_parse_header(line)
+      parts = _cgi_parseparam(';' + line).to_a
+      key = parts[0]
+      pdict = {}
 
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5') && ENV['OS'] == 'Windows_NT'
-  module RestClient
-    module Utils
-      def self.cgi_parse_header(line)
-        parts = _cgi_parseparam(';' + line).to_a
-        key = parts[0]
-        pdict = {}
+      while (p = parts.shift)
+        i = p.index('=')
+        next unless i
 
-        while (p = parts.shift)
-          i = p.index('=')
-          if i
-            name = p[0...i].strip.downcase
-            value = p[i+1..-1].strip
-            if value.length >= 2 && value[0] == '"' && value[-1] == '"'
-              value = value[1...-1]
-              value = value.gsub('\\\\', '\\').gsub('\\"', '"')
-            end
-            pdict[name] = value
-          end
+        name = p[0...i].strip.downcase
+        value = p[i + 1..-1].strip
+        if value.length >= 2 && value[0] == '"' && value[-1] == '"'
+          value = value[1...-1]
+          value = value.gsub('\\\\', '\\').gsub('\\"', '"')
         end
-  
-        [key, pdict]
+        pdict[name] = value
       end
+
+      [key, pdict]
     end
   end
 end

--- a/lib/rest-client/utils.rb
+++ b/lib/rest-client/utils.rb
@@ -2,7 +2,7 @@
 module RestClient
   # Utils contains the helper method that causes issues
   module Utils
-    # @note In Ruby versions greater than 2.4 on Windows, Discordrb's 
+    # @note In Ruby versions greater than 2.4 on Windows, Discordrb's
     # environment does not play nicely with the use of enumerators in
     # this specific function. The exact reason is unknown, but changing the use of
     # `Enumerator#next` into iteration via `Array#shift` prevents a silent crash.

--- a/lib/rest-client/utils.rb
+++ b/lib/rest-client/utils.rb
@@ -1,0 +1,31 @@
+# @note In Ruby versions greater than 2.4 on Windows, Discordrb's 
+# environment does not play nicely with the use of enumerators in
+# this specific function. The exact reason is unknown, but changing the use of
+# `Enumerator#next` into iteration via `Array#shift` prevents a silent crash.
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.5') && ENV['OS'] == 'Windows_NT'
+  module RestClient
+    module Utils
+      def self.cgi_parse_header(line)
+        parts = _cgi_parseparam(';' + line).to_a
+        key = parts[0]
+        pdict = {}
+
+        while (p = parts.shift)
+          i = p.index('=')
+          if i
+            name = p[0...i].strip.downcase
+            value = p[i+1..-1].strip
+            if value.length >= 2 && value[0] == '"' && value[-1] == '"'
+              value = value[1...-1]
+              value = value.gsub('\\\\', '\\').gsub('\\"', '"')
+            end
+            pdict[name] = value
+          end
+        end
+  
+        [key, pdict]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fix has been tested to work on Windows 7/8/10 with Ruby versions 2.5.0 and 2.5.1

Ref #455 