### PR TITLE
Add rest-client dependency restriction for Windows Ruby 2.5

### DIFF
--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client'
+  spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
 
   spec.required_ruby_version = '>= 2.1.0'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rest-client'
+  spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
   spec.add_dependency 'rbnacl', '~> 3.4.0' # 24: update


### PR DESCRIPTION
This should fix our 2.5 woes we've been having.

See #455 #474 

Starting up a bot for 24hr testing to test if stable.