### PR TITLE
Fix issue with ban reasons being mangled or rejected

### DIFF
--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 # API calls for Server
 module Discordrb::API::Server
   module_function
@@ -187,7 +189,7 @@ module Discordrb::API::Server
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason ? "&reason=#{reason}" : ''}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason ? "&reason=#{URI.escape(reason)}" : ''}",
       nil,
       Authorization: token
     )

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -1,4 +1,4 @@
-# API calls for Server
+e# API calls for Server
 module Discordrb::API::Server
   module_function
 
@@ -183,7 +183,7 @@ module Discordrb::API::Server
   # Ban a user from a server and delete their messages from the last message_days days
   # https://discordapp.com/developers/docs/resources/guild#create-guild-ban
   def ban_user(token, server_id, user_id, message_days, reason = nil)
-    reason = URI.escape(reason) if reason
+    reason = URI.encode(reason) if reason
     Discordrb::API.request(
       :guilds_sid_bans_uid,
       server_id,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -1,5 +1,3 @@
-require 'uri'
-
 # API calls for Server
 module Discordrb::API::Server
   module_function
@@ -185,11 +183,12 @@ module Discordrb::API::Server
   # Ban a user from a server and delete their messages from the last message_days days
   # https://discordapp.com/developers/docs/resources/guild#create-guild-ban
   def ban_user(token, server_id, user_id, message_days, reason = nil)
+    reason = URI.escape(reason) if reason
     Discordrb::API.request(
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason ? "&reason=#{URI.escape(reason)}" : ''}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason}" : ''}",
       nil,
       Authorization: token
     )

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -1,4 +1,4 @@
-e# API calls for Server
+# API calls for Server
 module Discordrb::API::Server
   module_function
 
@@ -188,7 +188,7 @@ module Discordrb::API::Server
       :guilds_sid_bans_uid,
       server_id,
       :put,
-      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}#{reason}" : ''}",
+      "#{Discordrb::API.api_base}/guilds/#{server_id}/bans/#{user_id}?delete-message-days=#{message_days}&reason=#{reason}",
       nil,
       Authorization: token
     )


### PR DESCRIPTION
Ban reasons, unusually, are sent in the query params rather than the request headers. This means they need to be URL encoded to work reliably. Currently this must be done manually, which this commit fixes.