### PR TITLE
Fix ReactionEvent not returning server

### DIFF
--- a/lib/discordrb/events/reactions.rb
+++ b/lib/discordrb/events/reactions.rb
@@ -42,7 +42,7 @@ module Discordrb::Events
 
     # @return [Server, nil] the server that was reacted in. If reacted in a PM channel, it will be nil.
     def server
-      @server ||= @channel.server
+      @server ||= channel.server
     end
   end
 


### PR DESCRIPTION
ReactionEvent's server attribute is trying to call @channel instead of channel, causing it to return nil always, which this commit fixes.