### PR TITLE
Update cached role on ROLE_CREATE

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -823,7 +823,12 @@ module Discordrb
       server_id = data['guild_id'].to_i
       server = @servers[server_id]
       new_role = Role.new(role_data, self, server)
-      server.add_role(new_role)
+      existing_role = server.role(new_role.id)
+      if existing_role
+        existing_role.update_from(new_role)
+      else
+        server.add_role(new_role)
+      end
     end
 
     # Internal handler for GUILD_ROLE_DELETE


### PR DESCRIPTION
In instances where we may already have a role cached internally, either because we just created the role or eventual consistency, we should update the cached role instead of always throwing the new instance into the cache.

This fixes situations where roles may be cached twice. (i.e., two instances of the same role on Discord's side)