### PR TITLE
Update to new Code Climate test reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,12 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - bundle exec rspec spec
-  - bundle exec codeclimate-test-reporter
   - bundle exec rubocop -c .rubocop.yml
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 # Test coverage reporting for CodeClimate
-gem 'codeclimate-test-reporter', group: :test, require: nil
-gem 'simplecov', group: :test
+# gem 'codeclimate-test-reporter', group: :test, require: nil
+gem 'simplecov', '~> 0.16.0', group: :test
 
 # Specify your gem's dependencies in discordrb.gemspec
 gemspec name: 'discordrb'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source 'https://rubygems.org'
 
-# Test coverage reporting for CodeClimate
-# gem 'codeclimate-test-reporter', group: :test, require: nil
-gem 'simplecov', '~> 0.16.0', group: :test
-
 # Specify your gem's dependencies in discordrb.gemspec
 gemspec name: 'discordrb'
 gemspec name: 'discordrb-webhooks', development_group: 'webhooks'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.4.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
   spec.add_development_dependency 'rubocop', '0.49.1'
+  spec.add_development_dependency 'simplecov', '~> 0.16.0'
 end


### PR DESCRIPTION
The Code Climate test reporter gem that currently being used is deprecated; this PR changes the CI config to use the [new method](https://docs.codeclimate.com/docs/configuring-test-coverage).

Please note that when these changes are made, the env variable set in Travis will need to change to `CC_TEST_REPORTER_ID`; see the above link for more details.