### PR TITLE
Add MiddlewareBot

### DIFF
--- a/examples/middleware_bot.rb
+++ b/examples/middleware_bot.rb
@@ -1,0 +1,95 @@
+require 'discordrb'
+require 'discordrb/middleware/middleware_bot'
+
+bot = Discordrb::Middleware::MiddlewareBot.new token: 'B0T.T0KEN.here'
+
+# Middleware that only yields on specific channels.
+# It can be configured to take channels by ID or by name per-handler.
+class ChannelFilter
+  def initialize(channels)
+    @channels = Array(channels)
+  end
+
+  def call(event, _state)
+    channel = event.channel
+
+    matches = @channels.any? do |c|
+      if c.is_a?(String)
+        c.delete('#') == channel.name
+      elsif c.is_a?(Integer)
+        c.id == channel.id
+      end
+    end
+
+    yield if matches
+  end
+end
+
+# Middleware that parses incoming messages and stores the results
+# in a state hash.
+class Parser
+  def initialize(prefix)
+    @prefix = prefix
+  end
+
+  def call(event, state)
+    split = event.message.content.split(' ')
+    command = split[0]
+    state[:command] = split[0][1..-1]
+    state[:arguments] = split[1..-1]
+
+    yield if command.start_with?(@prefix)
+  end
+end
+
+# Apply a middleware to an event by passing it as an argument.
+# This generates:
+#   - !add 2 3 1 (responds 6)
+#   - !ping (responds 'pong')
+bot.message(Parser.new('!')) do |event, state|
+  # Tap into the state hash set by your middleware:
+  case state[:command]
+  when 'add'
+    event.respond state[:arguments].map { |i| Integer(i) }.sum
+  when 'ping'
+    event.respond 'pong'
+  end
+end
+
+# Chain multiple middleware to create things like filters on certain
+# conditions. The following will only work in a channel named "general",
+# when the message starts with "?".
+# This generates:
+#   - ?info (responds 'made with discordrb')
+#   - ?emoji (posts a random custom emoji)
+bot.message(ChannelFilter.new('#general'), Parser.new('?')) do |event, state|
+  case state[:command]
+  when 'info'
+    event.respond 'made with discordrb'
+  when 'emoji'
+    event.respond bot.emoji.sample.to_s
+  end
+end
+
+# Fully compatible with exisitng event handler attributes. You specify them
+# after your middleware chain, just note that they will be considered *first*,
+# before your middleware is run.
+# This handler will only run in a channel with a specific ID, and when your
+# message starts with "foo".
+bot.message(ChannelFilter.new(246283902652645376), start_with: 'foo') do |event|
+  event.respond 'it works!'
+end
+
+# Use the same middleware on different kinds of events.
+# This handler will be annoying inside channels named "annoying"
+bot.typing(ChannelFilter.new('annoying')) do |event|
+  event.respond "Hi #{event.user.mention}, I'm annoying!"
+end
+
+# Don't want to write a class for something simple?
+# Write a proc literal:
+bot.message(Parser.new('?rand'), ->(_e, _s, &b) { b.call if rand(2).even? }) do |event|
+  event.respond 'lucky!'
+end
+
+bot.run

--- a/lib/discordrb/middleware/handler.rb
+++ b/lib/discordrb/middleware/handler.rb
@@ -1,0 +1,25 @@
+module Discordrb::Middleware
+  # Internal class that allows `Stack` instances to be used inside of a `Bot`s
+  # event loop.
+  # @!visibility private
+  class Handler
+    def initialize(stack, block)
+      @stack = stack
+      @block = block
+    end
+
+    # Conditional event matching is handled by middleware themselves,
+    # so a `Handler` matches on all events.
+    def matches?(_event)
+      true
+    end
+
+    # Executes the stack with the given event
+    def call(event)
+      @stack.run(event, &@block)
+    end
+
+    # TODO: Make some use of this?
+    def after_call(event); end
+  end
+end

--- a/lib/discordrb/middleware/handler_middleware.rb
+++ b/lib/discordrb/middleware/handler_middleware.rb
@@ -1,0 +1,15 @@
+module Discordrb::Middleware
+  # A stock middleware that allows usage of event handler classes from `Events`
+  # to be used in middleware chains.
+  # @!visibility private
+  class HandlerMiddleware
+    def initialize(handler)
+      @handler = handler
+    end
+
+    # Handle events
+    def call(event, _state)
+      yield if @handler.matches?(event)
+    end
+  end
+end

--- a/lib/discordrb/middleware/middleware_bot.rb
+++ b/lib/discordrb/middleware/middleware_bot.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'discordrb/bot'
+require 'discordrb/middleware/stack'
+require 'discordrb/middleware/handler'
+require 'discordrb/middleware/handler_middleware'
+
+# Module for middleware-related functionality
+module Discordrb::Middleware
+  # A {MiddlewareBot} is an extension of {Bot} that allows for event handlers
+  # that accept chains of custom objects, or *middleware*, that get run *before*
+  # your handler.
+  #
+  # A *middleware* can be *any* `class` that responds to `def call(event, state)`
+  # and optionally `yield`s. Whether or not your `call` `yield`s or not determines
+  # if the rest of the chain is executed.a
+  #
+  # In `call`, `event` will be the invoking Discord event, and `state` is an
+  # empty hash that you can store anything you like in that will persist across
+  # the events execution.
+  #
+  # You can also access the instances of middleware themselves by `state[MyMiddleware]`.
+  #
+  # Event attributes can be specified *after* your middleware chain, and they
+  # will be evaluated *before* your middleware.
+  # @example Basic custom middleware usage
+  #   class Prefix
+  #     def initialize(prefix)
+  #       @prefix = prefix
+  #     end
+  #
+  #     def call(_event, _state)
+  #       # Only continue if the message starts with our prefix
+  #       yield if event.message.content.start_with?(@prefix)
+  #     end
+  #   end
+  #
+  #   class RandomNumber
+  #     def call(_event, state)
+  #       # Store a random number to access later
+  #       state[:number] = rand(1..10)
+  #       yield
+  #     end
+  #   end
+  #
+  #   # Filter on messages in a channel named "general" that start with "!":
+  #   bot.message(Prefix.new('!'), RandomNumber.new, in: 'general') do |event, state|
+  #     command = event.message.content.split(' ').first
+  #     case command
+  #     when '!ping'
+  #       event.respond('pong')
+  #     when '!random'
+  #       # Access our `:number` that `RandomNumber` set for this event:
+  #       event.respond("Random number: #{state[:number]}")
+  #     else
+  #       event.repond("Unknown command, try `!ping` or `!random`")
+  #     end
+  #   end
+  # @example Middleware-only event handler
+  #   class RandomWord
+  #     def initialize(*words)
+  #       @words = words
+  #     end
+  #
+  #     def call(event, _state)
+  #       event.respond(@words.sample)
+  #     end
+  #   end
+  #
+  #   bot.message(RandomWord.new('Go to bed', 'Write more Ruby bots'),
+  #               starts_with: '!random')
+  class MiddlewareBot < Discordrb::Bot
+    class << self
+      # @!macro [attach] event_handler
+      #   @method $1(*middleware, **attributes, &block)
+      #     Registers an {$2} event handler.
+      #     @param [Array<#call>] middleware a list of objects that respond to `#call(event, state, &block)`
+      #     @param [Hash] attributes attributes to match for this event (See {EventContainer#$1})
+      #     @example
+      #       class MyMiddleware
+      #         def call(event, state)
+      #           event # => $2
+      #           state[:foo] = 'bar'
+      #           yield
+      #         end
+      #       end
+      #
+      #       bot.$1(MyMiddleware.new, attribute: 'foo') do |event, state|
+      #         event # => $2
+      #         state[:foo] # => 'bar'
+      #       end
+      # @!visibility private
+      def event_handler(name, klass)
+        define_method(name) do |*middleware, **attributes, &block|
+          unless attributes.empty?
+            handler = Discordrb::EventContainer.handler_class(klass).new(attributes, nil)
+            middleware.unshift(HandlerMiddleware.new(handler))
+          end
+          stack = Stack.new(middleware)
+          (event_handlers[klass] ||= []) << Handler.new(stack, block)
+        end
+      end
+    end
+
+    # @return [Hash<Event => Array<Handler>>] the event handlers registered on this bot
+    def event_handlers
+      @event_handlers ||= {}
+    end
+
+    event_handler :message, MessageEvent
+
+    event_handler :ready, ReadyEvent
+
+    event_handler :disconnected, DisconnectEvent
+
+    event_handler :heartbeat, HeartbeatEvent
+
+    event_handler :typing, TypingEvent
+
+    event_handler :message_edit, MessageEditEvent
+
+    event_handler :message_delete, MessageDeleteEvent
+
+    event_handler :reaction_add, ReactionAddEvent
+
+    event_handler :reaction_remove, ReactionRemoveEvent
+
+    event_handler :reaction_remove_all, ReactionRemoveAllEvent
+
+    event_handler :presence, PresenceEvent
+
+    event_handler :playing, PlayingEvent
+
+    event_handler :mention, MentionEvent
+
+    event_handler :channel_create, ChannelCreateEvent
+
+    event_handler :channel_update, ChannelUpdateEvent
+
+    event_handler :channel_delete, ChannelDeleteEvent
+
+    event_handler :channel_recipient_add, ChannelRecipientAddEvent
+
+    event_handler :channel_recipient_remove, ChannelRecipientRemoveEvent
+
+    event_handler :voice_state_update, VoiceStateUpdateEvent
+
+    event_handler :member_join, ServerMemberAddEvent
+
+    event_handler :member_update, ServerMemberUpdateEvent
+
+    event_handler :member_leave, ServerMemberDeleteEvent
+
+    event_handler :user_ban, UserBanEvent
+
+    event_handler :user_unban, UserUnbanEvent
+
+    event_handler :server_create, ServerCreateEvent
+
+    event_handler :server_update, ServerUpdateEvent
+
+    event_handler :server_delete, ServerDeleteEvent
+
+    event_handler :server_emoji, ServerEmojiChangeEvent
+
+    event_handler :server_emoji_create, ServerEmojiCreateEvent
+
+    event_handler :server_emoji_delete, ServerEmojiDeleteEvent
+
+    event_handler :server_emoji_update, ServerEmojiUpdateEvent
+
+    event_handler :webhook_update, WebhookUpdateEvent
+
+    event_handler :pm, PrivateMessageEvent
+
+    event_handler :raw, RawEvent
+
+    event_handler :unknown, UnknownEvent
+  end
+end

--- a/lib/discordrb/middleware/stack.rb
+++ b/lib/discordrb/middleware/stack.rb
@@ -1,0 +1,20 @@
+module Discordrb::Middleware
+  # Internal class that holds a chain of middleware.
+  # @!visibility private
+  class Stack
+    def initialize(middleware)
+      @middleware = middleware
+    end
+
+    # Runs an event object across this chain of middleware and optional block
+    def run(event, state = {}, index = 0, &block)
+      middleware = @middleware[index]
+      if middleware
+        state[middleware.class] = middleware
+        middleware.call(event, state) { run(event, state, index + 1, &block) }
+      elsif block_given?
+        yield event, state
+      end
+    end
+  end
+end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -1,0 +1,123 @@
+require 'discordrb'
+require 'discordrb/middleware/middleware_bot'
+
+module Discordrb::Middleware
+  describe Stack do
+    describe '#run' do
+      it 'calls each middleware' do
+        a_called = false
+        b_called = false
+
+        middleware = [
+          lambda do |_, _, &block|
+            a_called = true
+            block.call
+          end,
+          lambda do |_, _, &block|
+            b_called = true
+            block.call
+          end
+        ]
+        stack = described_class.new(middleware)
+        stack.run(double)
+
+        expect(a_called && b_called).to eq true
+      end
+
+      it "stops when a middleware doesn't yield" do
+        a_called = false
+        b_called = false
+
+        middleware = [
+          lambda do |_, _|
+            a_called = true
+          end,
+          lambda do |_, _, &block|
+            b_called = true
+            block.call
+          end
+        ]
+        stack = described_class.new(middleware)
+        stack.run(double)
+
+        expect(a_called && b_called).to eq false
+      end
+
+      it 'calls a passed block at the end of the chain' do
+        a_called = false
+        b_called = false
+
+        middleware = [
+          lambda do |_, _, &block|
+            a_called = true
+            block.call
+          end
+        ]
+        stack = described_class.new(middleware)
+        stack.run(double) { b_called = true }
+
+        expect(a_called && b_called).to eq true
+      end
+    end
+  end
+
+  describe Handler do
+    subject(:handler) { described_class.new(double(:run), double) }
+
+    describe '#matches?' do
+      it 'always returns true' do
+        expect(handler.matches?(double)).to eq true
+      end
+    end
+
+    describe '#after_call' do
+      it 'does nothing' do
+        expect(handler.after_call(double)).to be_falsey
+      end
+    end
+
+    describe '#call' do
+      it 'runs the contained stack' do
+        stack = double(:run)
+        proc = proc {}
+        event = double
+
+        handler = described_class.new(stack, proc)
+        expect(stack).to receive(:run).with(event) do |_event, &block|
+          expect(block).to be(proc)
+        end
+        handler.call(event)
+      end
+    end
+  end
+
+  describe HandlerMiddleware do
+    describe '#call' do
+      it 'yields with a matching event' do
+        handler = double
+        event = double
+        allow(handler).to receive(:matches?).with(event).and_return(true)
+        called = false
+
+        middleware = described_class.new(handler)
+        middleware.call(event, nil) do
+          called = true
+        end
+        expect(called).to eq true
+      end
+
+      it "doesn't yield with a non-matching event" do
+        handler = double
+        event = double
+        allow(handler).to receive(:matches?).with(event).and_return(false)
+        called = false
+
+        middleware = described_class.new(handler)
+        middleware.call(event, nil) do
+          called = true
+        end
+        expect(called).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
To any watchers; please :+1: or :-1: if you like or dislike this - it will help us gage whether something like this should be merged :smiley_cat: 

---

This is a design pattern I've been using a lot lately in Crystal, and I think it could serve useful to a particular audience of discordrb "power users".

**The Problem:** `Bot` and `CommandBot` offer a limited set of options for configuring behavior and filtering incoming events. For example:
- In `bot.message`, you can use `in:`, `start_with:`.
- In `bot.command` you can use `required_roles:`, `permission_level:`

**If you want to change their behavior or add new options**, you have to:
- Write a bunch of duplicated code (`next unless...; next unless...`)
- Hack the library
- Come up with an entirely custom system that wraps `Bot`, or that your handlers dispatch to. Less experienced developers who want more out of `Bot` and `CommandBot` will find this the most difficult, and probably lead to very messy abstractions.
- Collaboration on advanced bots is more difficult because of these overly complex helpers that each developer creates.
- Your hacks that you add or implementations you create will probably be difficult to spec.

**This PR adds a new `Bot`, `MiddlewareBot`, that attempts to address all of those:**
- Instead of hacking the library, `MiddlewareBot`s handlers give you a place to inject your own code that receives a callback in a DRY way that you can re-use everywhere.
- Instead of designing a totally custom helper system from scratch, this gives you footing - a template to start with, that follows some basic rules: 
1. A `class` that responds to `def call(event, state)`. 
2. You chain these classes onto event handlers and they are executed in sequence. 
3. Whether or not your `call` method `yield`s determines if the rest of the chain is executed.
- Developers who work together using `MiddlewareBot` are now all using the same system to inject whatever custom code they want.
- Speccing middleware is *easy*: Throw whatever doubles you want down `call`.
- You can still use the regular event attributes (`in:`, `start_with:`) alongside middleware; porting an existing `Bot` is free.

---

Please read the examples and documentation I've written, as this is a simple concept that has a *lot* of implications - use your imagination when looking at these examples! If you have any questions, please review or ask me on Discord.

This could even simply replace `Bot`/`EventContainer` entirely as it would not be a breaking change at all because of the way this works!; however I figure, if we want this, it would be best as its own `Bot` class for at least one major release.

I could have written a `Container` module for this bot, but that can come in a later step.

Long term, this could also be used to clean up `Events` code internally in a really nice way, providing an easy vehicle to spec them as well.