### PR TITLE
Add blocking await methods

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -564,7 +564,7 @@ module Discordrb
     # @option attributes [Numeric] :timeout the amount of time to wait for a response before returning `nil`. Waits forever if omitted.
     # @return [Event, nil] The event object that was triggered, or `nil` if a `timeout` was set and no event was raised in time.
     # @raise [ArgumentError] if `timeout` is given and is not a positive numeric value
-    def add_await!(key, type, attributes = {})
+    def add_await!(type, attributes = {})
       raise "You can't await an AwaitEvent!" if type == Discordrb::Events::AwaitEvent
 
       timeout = attributes[:timeout]

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -238,6 +238,13 @@ module Discordrb
       @bot.add_await(key, Discordrb::Events::MessageEvent, { from: @id }.merge(attributes), &block)
     end
 
+    # Add a blocking await for a message from this user. Specifically, this adds a global await for a MessageEvent with this
+    # user's ID as a :from attribute.
+    # @see Bot#add_await!
+    def await!(attributes = {})
+      @bot.add_await!(Discordrb::Events::MessageEvent, { from: @id }.merge(attributes))
+    end
+
     # Gets the member this user is on a server
     # @param server [Server] The server to get the member for
     # @return [Member] this user as a member on a particular server
@@ -1786,6 +1793,13 @@ module Discordrb
       @bot.add_await(key, Discordrb::Events::MessageEvent, { in: @id }.merge(attributes), &block)
     end
 
+    # Add a blocking {Await} for a message in this channel. This is identical in functionality to adding a
+    # {Discordrb::Events::MessageEvent} await with the `in` attribute as this channel.
+    # @see Bot#add_await!
+    def await!(attributes = {})
+      @bot.add_await!(Discordrb::Events::MessageEvent, { in: @id }.merge(attributes))
+    end
+
     # Creates a new invite to this channel.
     # @param max_age [Integer] How many seconds this invite should last.
     # @param max_uses [Integer] How many times this invite should be able to be used.
@@ -2438,6 +2452,12 @@ module Discordrb
     # @see Bot#add_await
     def await(key, attributes = {}, &block)
       @bot.add_await(key, Discordrb::Events::MessageEvent, { from: @author.id, in: @channel.id }.merge(attributes), &block)
+    end
+
+    # Add a blocking {Await} for a message with the same user and channel.
+    # @see Bot#add_await!
+    def await!(attributes = {})
+      @bot.add_await!(Discordrb::Events::MessageEvent, { from: @author.id, in: @channel.id }.merge(attributes))
     end
 
     # @return [true, false] whether this message was sent by the current {Bot}.


### PR DESCRIPTION
With this PR, we can now do this:
```rb
require "discordrb"

bot = Discordrb::Bot.new token: ENV["TOKEN"]

bot.message(with_text: '!test') do |event|
  event.respond 'What is your name?'

  # Execution of this event pauses here until a matching event is raised:
  response = event.user.await!(:"quiz_#{event.user.id}")

  event.respond "Hello #{response.content}!"
end

bot.run
```

Motivation: Lots of users look for awaits (or just ask in general) in order to provide conversational behavior, similar to how one would make a basic CLI application with `gets`. Ultimately they get confused with how awaits work and their async nature, how to persist/kill the await, or the fact that you can't do "nested" or "chained" awaits (unless you provide some of your own infrastructure) at the moment.

I think `key` is still confusing too to some users. Maybe we can intelligently provide a default or store awaits in some other way, but I won't cover that in this PR.

Currently the API is `#await!` ("bang for blocking"). I like this semantic but I'm open to other suggestions. A flag on `#await` I think isn't acceptable, this behavior is too different and needs to be distinguished. Maybe `#await_sync`, if that isn't too confusing.. perhaps an entirely different name.

I barely touched the documentation, so please suggest improvements. I think at the least `@example` should be added to `User#await`, `Channel#await`, and `Message#await`.