### PR TITLE
Add attr_reader :server to Role

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -878,7 +878,7 @@ module Discordrb
 
     # @return [String] this role's name ("new role" if it hasn't been changed)
     attr_reader :name
-    
+
     # @return [Server] the server this role belongs to
     attr_reader :server
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -878,6 +878,9 @@ module Discordrb
 
     # @return [String] this role's name ("new role" if it hasn't been changed)
     attr_reader :name
+    
+    # @return [Server] the server this role belongs to
+    attr_reader :server
 
     # @return [true, false] whether or not this role should be displayed separately from other users
     attr_reader :hoist


### PR DESCRIPTION
Needed to know which server the role belongs to an event and found that the server isn't exposed on `Role`