### PR TITLE
 Call events over a copy of event handlers

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1271,8 +1271,10 @@ module Discordrb
 
       @event_handlers ||= {}
       handlers = @event_handlers[event.class]
-      (handlers || []).each do |handler|
-        call_event(handler, event) if handler.matches?(event)
+      if handlers
+        handlers.dup.each do |handler|
+          call_event(handler, event) if handler.matches?(event)
+        end
       end
     end
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1271,10 +1271,9 @@ module Discordrb
 
       @event_handlers ||= {}
       handlers = @event_handlers[event.class]
-      if handlers
-        handlers.dup.each do |handler|
-          call_event(handler, event) if handler.matches?(event)
-        end
+      return unless handlers
+      handlers.dup.each do |handler|
+        call_event(handler, event) if handler.matches?(event)
       end
     end
 


### PR DESCRIPTION
Fixes #513 

Consider an event handler that registers event handlers:

```rb
bot.message do |outer|
  outer.respond "outer"

  bot.message do |inner|
    inner.respond "inner"
  end
end
```

When we raise an event, internally we will be iterating over `@event_handlers[MessageEvent]`. When this handler is executed in its own thread, it *will mutate* `@event_handlers[MessageEvent]`, appending the inner event handler.

It is possible that the dispatch of an event will take too long, and the inner event handler will be called by the same event as the outer event handler.

I believe any user doing this is going to expect the inner event to *not* be raised. This is a race condition that has probably been happening for a long time, but the blocking awaits feature happens to be very efficient at exploiting it  causing #513 to come up.

This fixes this by iterating over a copy of the event handlers when we dispatch the event, guaranteeing that it won't be mutated. I wrap this in a check for existing handlers first, so we don't duplicate handlers for extremely heavy events like `PRESENCE_UPDATE` unless the user has actually registered handlers for that kind of event, so hopefully the performance impact is negligible.

Also see:

- My analysis of the issue https://github.com/meew0/discordrb/issues/513#issuecomment-403632937
- A reduced example of the bug https://carc.in/#/r/4h5u, and fixed: https://carc.in/#/r/4h5q
