### PR TITLE
Add changelog link to gem metadata

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|examples|lib/discordrb/webhooks)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.metadata = {
+    'changelog_uri' => 'https://github.com/meew0/discordrb/blob/master/CHANGELOG.md'
+  }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'


### PR DESCRIPTION
Will put a nice link to the changelog right on the rubygems.org page like so: ![image](https://user-images.githubusercontent.com/2047515/43158300-983e2878-8f3c-11e8-843f-5a0ed42ecc07.png)
