### PR TITLE
Embed#colour= accepts #to_i, add ColourRGB#to_i

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -4136,6 +4136,7 @@ module Discordrb
 
     # @return [Integer] the colour's RGB values combined into one integer.
     attr_reader :combined
+    alias_method :to_i, :combined
 
     # Make a new colour from the combined value.
     # @param combined [Integer, String] The colour's RGB values combined into one integer or a hexadecimal string

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -8,7 +8,7 @@ module Discordrb::Webhooks
       @description = description
       @url = url
       @timestamp = timestamp
-      self.colour = colour || color
+      self.colour = colour || color if colour || color
       @footer = footer
       @image = image
       @thumbnail = thumbnail
@@ -35,10 +35,12 @@ module Discordrb::Webhooks
     alias_method :color, :colour
 
     # Sets the colour of the bar to the side of the embed to something new.
-    # @param value [Integer, String, {Integer, Integer, Integer}] The colour in decimal, hexadecimal, or R/G/B decimal
+    # @param value [Integer, String, {Integer, Integer, Integer}, #to_i] The colour in decimal, hexadecimal, or R/G/B decimal
     #   form.
     def colour=(value)
-      if value.is_a? Integer
+      if value.nil?
+        @colour = nil
+      elsif value.is_a? Integer
         raise ArgumentError, 'Embed colour must be 24-bit!' if value >= 16_777_216
         @colour = value
       elsif value.is_a? String
@@ -46,6 +48,8 @@ module Discordrb::Webhooks
       elsif value.is_a? Array
         raise ArgumentError, 'Colour tuple must have three values!' if value.length != 3
         self.colour = value[0] << 16 | value[1] << 8 | value[2]
+      else
+        self.colour = value.to_i
       end
     end
 

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -35,7 +35,7 @@ module Discordrb::Webhooks
     alias_method :color, :colour
 
     # Sets the colour of the bar to the side of the embed to something new.
-    # @param value [Integer, String, {Integer, Integer, Integer}, #to_i] The colour in decimal, hexadecimal, or R/G/B decimal
+    # @param value [Integer, String, {Integer, Integer, Integer}, #to_i, nil] The colour in decimal, hexadecimal, R/G/B decimal, or nil to clear the embeds colour
     #   form.
     def colour=(value)
       if value.nil?

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -8,7 +8,7 @@ module Discordrb::Webhooks
       @description = description
       @url = url
       @timestamp = timestamp
-      self.colour = colour || color if colour || color
+      self.colour = colour || color
       @footer = footer
       @image = image
       @thumbnail = thumbnail


### PR DESCRIPTION
This allows instances of `ColourRGB` to be passed to `embed.color=`.

Previously `#color=` ignored any class that wasn't `String`, `Integer`, or `Array`, resulting in nothing happening.

```rb
bot.command(:foo) do |event|
  event.channel.send_embed do |embed|
    embed.color = event.user.color
  end
end
```