### PR TITLE
Implement CommandAlias

### DIFF
--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -143,7 +143,7 @@ module Discordrb::Commands
         if command_name
           command = @commands[command_name.to_sym]
           if command.is_a?(CommandAlias)
-            command = @commands[command.name] if command.is_a?(CommandAlias)
+            command = @commands[command.name]
             command_name = command.name
           end
           return "The command `#{command_name}` does not exist!" unless command

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -55,6 +55,8 @@ module Discordrb::Commands
     # @note `LocalJumpError`s are rescued from internally, giving bots the opportunity to use `return` or `break` in
     #   their blocks without propagating an exception.
     # @return [Command] The command that was added.
+    # @deprecated The command name argument will no longer support arrays in the next release.
+    #   Use the `aliases` attribute instead.
     def command(name, attributes = {}, &block)
       @commands ||= {}
       if name.is_a? Array

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -67,7 +67,11 @@ module Discordrb::Commands
 
         new_command
       else
-        @commands[name] = Command.new(name, attributes, &block)
+        new_command = Command.new(name, attributes, &block)
+        @commands[name] = new_command
+        new_command.attributes[:aliases].each do |aliased_name|
+          @commands[aliased_name] = CommandAlias.new(aliased_name, new_command)
+        end
       end
     end
 

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -68,10 +68,10 @@ module Discordrb::Commands
         new_command
       else
         new_command = Command.new(name, attributes, &block)
-        @commands[name] = new_command
         new_command.attributes[:aliases].each do |aliased_name|
           @commands[aliased_name] = CommandAlias.new(aliased_name, new_command)
         end
+        @commands[name] = new_command
       end
     end
 

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -63,7 +63,10 @@ module Discordrb::Commands
         bucket: attributes[:bucket],
 
         # Block for handling internal exceptions, or a string to respond with
-        rescue: attributes[:rescue]
+        rescue: attributes[:rescue],
+
+        # A list of aliases that reference this command
+        aliases: attributes[:aliases] || []
       }
 
       @block = block
@@ -117,6 +120,22 @@ module Discordrb::Commands
       end
 
       raise exception
+    end
+  end
+
+  # A command that references another command
+  class CommandAlias
+    # @return [Symbol] the name of this alias
+    attr_reader :aliased_name
+
+    def initialize(aliased_name, command)
+      @aliased_name = aliased_name
+      @command = command
+    end
+
+    def method_missing(method, *args, &block)
+      # Calls are forwarded to the command
+      @command.send(method, *args, &block)
     end
   end
 

--- a/lib/discordrb/commands/parser.rb
+++ b/lib/discordrb/commands/parser.rb
@@ -126,16 +126,14 @@ module Discordrb::Commands
   # A command that references another command
   class CommandAlias
     # @return [Symbol] the name of this alias
-    attr_reader :aliased_name
+    attr_reader :name
 
-    def initialize(aliased_name, command)
-      @aliased_name = aliased_name
-      @command = command
-    end
+    # @return [Command] the command this alias points to
+    attr_reader :aliased_command
 
-    def method_missing(method, *args, &block)
-      # Calls are forwarded to the command
-      @command.send(method, *args, &block)
+    def initialize(name, aliased_command)
+      @name = name
+      @aliased_command = aliased_command
     end
   end
 


### PR DESCRIPTION
This adds CommandAlias as a pass-through to another command as an alternative of "duplicating" commands with passing an array of symbols as a name. Aliases will be shown in the help command, and asking for help on a command alias will defer to the original command's help.

## Example

```rb
bot.command(:ping, aliases: [:p, :pong]) { "pong" }
```
![image](https://user-images.githubusercontent.com/6119032/44596467-42a96500-a79a-11e8-9427-92ba97a68c78.png)

I don't know if we want to accept this, but I did it anyway, so user feedback will decide which way we want to go with it.

## Todo

(if we want this)

- Should OG command aliases should be removed? `command([:ping, :p])`
- Fix rubocop
- Update documentation