### PR TITLE
Support zlib-stream gateway compression

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -97,11 +97,16 @@ module Discordrb
     #   https://github.com/hammerandchisel/discord-api-docs/issues/17 for how to do sharding.
     # @param redact_token [true, false] Whether the bot should redact the token in logs. Default is true.
     # @param ignore_bots [true, false] Whether the bot should ignore bot accounts or not. Default is false.
+    # @param compress_mode [:none, :large, :stream] Sets which compression mode should be used when connecting
+    #   to Discord's gateway. `:none` will request that no payloads are sent compressed (not recommended for
+    #   production bots). `:large` will request that large payloads are sent compressed. `:stream` will request
+    #   that all data be sent in a continuous compressed stream.
     def initialize(
         log_mode: :normal,
         token: nil, client_id: nil,
         type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
-        shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false
+        shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
+        compress_mode: :stream
     )
       LOGGER.mode = log_mode
       LOGGER.token = token if redact_token
@@ -118,8 +123,10 @@ module Discordrb
       LOGGER.fancy = fancy_log
       @prevent_ready = suppress_ready
 
+      @compress_mode = compress_mode
+
       @token = process_token(@type, token)
-      @gateway = Gateway.new(self, @token, @shard_key)
+      @gateway = Gateway.new(self, @token, @shard_key, @compress_mode)
 
       init_cache
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -98,9 +98,9 @@ module Discordrb
     # @param redact_token [true, false] Whether the bot should redact the token in logs. Default is true.
     # @param ignore_bots [true, false] Whether the bot should ignore bot accounts or not. Default is false.
     # @param compress_mode [:none, :large, :stream] Sets which compression mode should be used when connecting
-    #   to Discord's gateway. `:none` will request that no payloads are sent compressed (not recommended for
-    #   production bots). `:large` will request that large payloads are sent compressed. `:stream` will request
-    #   that all data be sent in a continuous compressed stream.
+    #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
+    #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
+    #   that all data be received in a continuous compressed stream.
     def initialize(
         log_mode: :normal,
         token: nil, client_id: nil,

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -82,7 +82,8 @@ module Discordrb::Commands
         shard_id: attributes[:shard_id],
         num_shards: attributes[:num_shards],
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
-        ignore_bots: attributes[:ignore_bots])
+        ignore_bots: attributes[:ignore_bots],
+        compress_mode: attributes[:compress_mode])
 
       @prefix = attributes[:prefix]
       @attributes = {

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -143,7 +143,7 @@ module Discordrb
     # @return [true, false] whether or not this gateway should check for heartbeat ACKs.
     attr_accessor :check_heartbeat_acks
 
-    def initialize(bot, token, shard_key = nil)
+    def initialize(bot, token, shard_key = nil, compress_mode = :stream)
       @token = token
       @bot = bot
 
@@ -155,6 +155,8 @@ module Discordrb
       @ws_success = false
 
       @check_heartbeat_acks = true
+
+      @compress_mode = compress_mode
     end
 
     # Connect to the gateway server in a separate thread
@@ -263,13 +265,14 @@ module Discordrb
     # Identifies to Discord with the default parameters.
     # @see #send_identify
     def identify
+      compress = @compress_mode == :large
       send_identify(@token, {
                       '$os': RUBY_PLATFORM,
                       '$browser': 'discordrb',
                       '$device': 'discordrb',
                       '$referrer': '',
                       '$referring_domain': ''
-                    }, true, 100, @shard_key)
+                    }, compress, 100, @shard_key)
     end
 
     # Sends an identify packet (op 2). This starts a new session on the current connection and tells Discord who we are.
@@ -523,8 +526,13 @@ module Discordrb
       # Append a slash in case it's not there (I'm not sure how well WSCS handles it otherwise)
       raw_url += '/' unless raw_url.end_with? '/'
 
-      # Add the parameters we want
-      raw_url + "?encoding=json&v=#{GATEWAY_VERSION}"
+      query = if @compress_mode == :stream
+                "?encoding=json&v=#{GATEWAY_VERSION}&compress=zlib-stream"
+              else
+                "?encoding=json&v=#{GATEWAY_VERSION}"
+              end
+
+      raw_url + query
     end
 
     def connect
@@ -536,6 +544,12 @@ module Discordrb
 
       # Parse it
       gateway_uri = URI.parse(url)
+
+      # Zlib context for this gateway connection
+      @zlib_reader = Zlib::Inflate.new
+
+      # Buffer for partial Zlib payloads
+      @zlib_buffer = StringIO.new
 
       # Connect to the obtained URI with a socket
       @socket = obtain_socket(gateway_uri)
@@ -624,10 +638,20 @@ module Discordrb
       LOGGER.log_exception(e)
     end
 
+    ZLIB_SUFFIX = "\x00\x00\xFF\xFF".b.freeze
+
     def handle_message(msg)
-      if msg.byteslice(0) == 'x'
-        # The message is compressed, inflate it
-        msg = Zlib::Inflate.inflate(msg)
+      if @compress_mode == :large
+        if msg.byteslice(0) == 'x'
+          # The message is compressed, inflate it
+          msg = Zlib::Inflate.inflate(msg)
+        end
+      elsif @compress_mode == :stream
+        @zlib_buffer << msg
+        return if msg.bytesize < 4 || msg.byteslice(-4, 4) != ZLIB_SUFFIX
+        @zlib_buffer.rewind
+        msg = @zlib_reader.inflate(@zlib_buffer.string)
+        @zlib_buffer.truncate(0)
       end
 
       # Parse packet

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -647,11 +647,18 @@ module Discordrb
           msg = Zlib::Inflate.inflate(msg)
         end
       elsif @compress_mode == :stream
+        # Write deflated string to buffer
         @zlib_buffer << msg
+
+        # Check if message ends in `ZLIB_SUFFIX`
         return if msg.bytesize < 4 || msg.byteslice(-4, 4) != ZLIB_SUFFIX
-        @zlib_buffer.rewind
-        msg = @zlib_reader.inflate(@zlib_buffer.string)
-        @zlib_buffer.truncate(0)
+
+        # Inflate the deflated buffer
+        deflated = @zlib_buffer.string
+        msg = @zlib_reader.inflate(deflated)
+
+        # Clear the buffer for the next message
+        @zlib_buffer.reopen('')
       end
 
       # Parse packet

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -548,9 +548,6 @@ module Discordrb
       # Zlib context for this gateway connection
       @zlib_reader = Zlib::Inflate.new
 
-      # Buffer for partial Zlib payloads
-      @zlib_buffer = StringIO.new
-
       # Connect to the obtained URI with a socket
       @socket = obtain_socket(gateway_uri)
       LOGGER.debug('Obtained socket')
@@ -648,17 +645,13 @@ module Discordrb
         end
       elsif @compress_mode == :stream
         # Write deflated string to buffer
-        @zlib_buffer << msg
+        @zlib_reader << msg
 
         # Check if message ends in `ZLIB_SUFFIX`
         return if msg.bytesize < 4 || msg.byteslice(-4, 4) != ZLIB_SUFFIX
 
         # Inflate the deflated buffer
-        deflated = @zlib_buffer.string
-        msg = @zlib_reader.inflate(deflated)
-
-        # Clear the buffer for the next message
-        @zlib_buffer.reopen('')
+        msg = @zlib_reader.inflate('')
       end
 
       # Parse packet


### PR DESCRIPTION
This also lets users pick between compression modes in `Bot.new`.

This needs testing and profiling on larger bots, so anyone watching this PR, please feel free to try this patch on your own bots and give any feedback. If there are no issues, this *should* be the default setting (as I've set it in this PR).