### PR TITLE
Enable SSLSocket certificate verification, enforce TLSv1.2

### DIFF
--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -491,14 +491,19 @@ module Discordrb
 
       if secure_uri?(uri)
         ctx = OpenSSL::SSL::SSLContext.new
-        ctx.ssl_version = 'SSLv23'
-        ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE # use VERIFY_PEER for verification
 
-        cert_store = OpenSSL::X509::Store.new
-        cert_store.set_default_paths
-        ctx.cert_store = cert_store
+        if ENV['DISCORDRB_SSL_VERIFY_NONE']
+          ctx.ssl_version = 'SSLv23'
+          ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE # use VERIFY_PEER for verification
 
-        socket = ::OpenSSL::SSL::SSLSocket.new(socket, ctx)
+          cert_store = OpenSSL::X509::Store.new
+          cert_store.set_default_paths
+          ctx.cert_store = cert_store
+        else
+          ctx.set_params ssl_version: :TLSv1_2
+        end
+
+        socket = OpenSSL::SSL::SSLSocket.new(socket, ctx)
         socket.connect
       end
 


### PR DESCRIPTION
This PR enables certificate verification when using an `SSLSocket` wrapper. 

Because I'm weary of how this may affect users (namely on Windows), it is enabled by default but the old code path can be used by setting `DISCORDRB_SSL_VERIFY_NONE`. If there are no issues come 4.0, we can remove this option.

Thank you to @cky for pointing this out and providing a code example.