### PR TITLE
Add flag to allow bot to treat edited message as if they're new messages

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -101,17 +101,20 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
+    # @params parse_edited [true, false] Whether the bot should treat edited messages as a new message when 
+    #   processing commands.
     def initialize(
         log_mode: :normal,
         token: nil, client_id: nil,
         type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
         shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
-        compress_mode: :stream
+        compress_mode: :stream, parse_edited: false
     )
       LOGGER.mode = log_mode
       LOGGER.token = token if redact_token
 
       @should_parse_self = parse_self
+      @parse_edited = parse_edited
 
       @client_id = client_id
 
@@ -1052,6 +1055,11 @@ module Discordrb
 
         event = MessageEditEvent.new(message, self)
         raise_event(event)
+
+        if @parse_edited
+          event = MessageEvent.new(message, self)
+          raise_event(event)
+        end
       when :MESSAGE_DELETE
         delete_message(data)
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -101,7 +101,7 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @param parse_edited [true, false] Whether the bot should treat edited messages as a new message when 
+    # @param parse_edited [true, false] Whether the bot should treat edited messages as a new message when
     #   processing commands.
     def initialize(
         log_mode: :normal,

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -101,7 +101,7 @@ module Discordrb
     #   to Discord's gateway. `:none` will request that no payloads are received compressed (not recommended for
     #   production bots). `:large` will request that large payloads are received compressed. `:stream` will request
     #   that all data be received in a continuous compressed stream.
-    # @params parse_edited [true, false] Whether the bot should treat edited messages as a new message when 
+    # @param parse_edited [true, false] Whether the bot should treat edited messages as a new message when 
     #   processing commands.
     def initialize(
         log_mode: :normal,

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -83,9 +83,8 @@ module Discordrb::Commands
         num_shards: attributes[:num_shards],
         redact_token: attributes.key?(:redact_token) ? attributes[:redact_token] : true,
         ignore_bots: attributes[:ignore_bots],
-        compress_mode: attributes[:compress_mode])
-
-      @parse_edited = attributes[:parse_edited]
+        compress_mode: attributes[:compress_mode],
+        parse_edited: attributes[:parse_edited])
 
       @prefix = attributes[:prefix]
       @attributes = {

--- a/lib/discordrb/commands/command_bot.rb
+++ b/lib/discordrb/commands/command_bot.rb
@@ -85,6 +85,8 @@ module Discordrb::Commands
         ignore_bots: attributes[:ignore_bots],
         compress_mode: attributes[:compress_mode])
 
+      @parse_edited = attributes[:parse_edited]
+
       @prefix = attributes[:prefix]
       @attributes = {
         # Whether advanced functionality such as command chains are enabled
@@ -392,6 +394,10 @@ module Discordrb::Commands
 
       # Return the message so it doesn't get parsed again during the rest of the dispatch handling
       message
+    end
+
+    def update_message(data)
+      create_message(data) if @parse_edited
     end
 
     # Check whether a message should trigger command execution, and if it does, return the raw chain


### PR DESCRIPTION
I've had a lot of users ask me to implement this on my bot, and I couldn't find a built-in way to do it. Hopefully this is an acceptable way to go about it.

Basically lets people edit the message to fix typos, and still run the command. So if you have a command `:name`, and someone typed `nam`, they could edit the message and it would run the command, instead of retyping the whole thing.