### PR TITLE
Add "Priority Speaker" as bit 8

### DIFF
--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -15,7 +15,7 @@ module Discordrb
       5 => :manage_server,         # 32
       6 => :add_reactions,         # 64
       7 => :view_audit_log,        # 128
-      # 8                          # 256
+      8 => :priority_speaker,      # 256
       # 9                          # 512
       10 => :read_messages,        # 1024
       11 => :send_messages,        # 2048


### PR DESCRIPTION
Recently Discord added a permission value for 256, that being Priority speaker.
Check this example
![image](https://user-images.githubusercontent.com/8278263/44948211-575fab80-addf-11e8-91ca-555e37841b67.png)
Not sure how useful this could be or if I'm missing anything, but I just saw it wasn't even there.