### PR TITLE
Add send_messages argument to Server#default_channel

### DIFF
--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -2884,16 +2884,17 @@ module Discordrb
       @owner = member(@owner_id) if exists
     end
 
-    # The default channel is the text channel on this server with the highest position.
-    # that the client has Read Messages permission on.
+    # The default channel is the text channel on this server with the highest position
+    # that the bot has Read Messages permission on.
+    # @param send_messages [true, false] whether to additionally consider if the bot has Send Messages permission
     # @return [Channel, nil] The default channel on this server, or `nil` if there are no channels that the bot can read.
-    def default_channel
+    def default_channel(send_messages = false)
+      bot_member = member(@bot.profile)
       text_channels.sort_by { |e| [e.position, e.id] }.find do |e|
-        overwrite = e.permission_overwrites[id]
-        if overwrite
-          overwrite.allow.read_messages || overwrite.allow.read_messages == overwrite.deny.read_messages
+        if send_messages
+          bot_member.can_read_messages?(e) && bot_member.can_send_messages?(e)
         else
-          everyone_role.permissions.read_messages
+          bot_member.can_read_messages?(e)
         end
       end
     end


### PR DESCRIPTION
Consider the bots member on the server when calculating default_channel

Closes #532 

Example:
```irb
[9] pry(main)> s = bot.server(81384788765712384)
=> <Server name=Discord API id=81384788765712384 large=true region= owner=#<Discordrb::User:0x00007eff71402b40> afk_channel_id= system_channel_id= afk_timeout=3600>
[10] pry(main)> s.default_channel
=> <Channel name=rules id=381898062269775883 topic="" type=0 position=0 server=#<Discordrb::Server:0x00007eff71c5f090>>
[11] pry(main)> s.default_channel(true)
=> <Channel name=crystal_discordcr id=381889335278043137 topic="<:crystal:232905855618514944> Use `!sub news` to subscribe to updates. Latest version: 0.4.0.

GitHub: https://github.com/meew0/discordcr
Crystal: https://crystal-lang.org/
Docs: https://meew0.github.io/discordcr/doc/master/" type=0 position=10 server=#<Discordrb::Server:0x00007eff71c5f090>>
```