### PR TITLE
Update ffi dependency to >= 1.9.24

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
   spec.add_dependency 'rbnacl', '~> 3.4.0' # 24: update
+  spec.add_dependency 'ffi', '>= 1.9.24'
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.2.0.1'
 


### PR DESCRIPTION
Our dependencies (rbnacl, opus-ruby) do not pin a specific FFI version, which may cause a vulnerable version of FFI to be accepted per [CVE-2018-1000201](https://nvd.nist.gov/vuln/detail/CVE-2018-1000201) if the user happens to have an older version already installed.