### PR TITLE
Check against the name of a user's game in PRESENCE_UPDATE

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1105,7 +1105,7 @@ module Discordrb
         # Ignore friends list presences
         return unless data['guild_id']
 
-        now_playing = data['game']
+        now_playing = data['game'].nil? ? nil : data['game']['name']
         presence_user = @users[data['user']['id'].to_i]
         played_before = presence_user.nil? ? nil : presence_user.game
         update_presence(data)


### PR DESCRIPTION
Prior, we were comparing the full *game* object - which is a hash with several fields - with User#game, which is just a String. This caused PresenceEvent to never be raised because the following `if` would always
be truthy.

Note that eventually we should actually compare against an object and expose more data with `User#activities`. This will serve as a quick fix in the meantime.