### PR TITLE
Implement Paginator utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Server#bot` method for obtaining your bot's own `Member` on a particular server ([#597](https://github.com/meew0/discordrb/pull/597))
 - `Attachment#spoiler?`, to check if an attachment is a spoiler or not ([#603](https://github.com/meew0/discordrb/pull/603), thanks @swarley)
 - Methods on `Server` to manage the server's emoji ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
+- `Paginator` utility class for wrapping paginated endpoints ([#579](https://github.com/meew0/discordrb/pull/579))
 
 ### Changed
 

--- a/lib/discordrb/data.rb
+++ b/lib/discordrb/data.rb
@@ -11,6 +11,7 @@ require 'discordrb/api/invite'
 require 'discordrb/api/user'
 require 'discordrb/api/webhook'
 require 'discordrb/webhooks/embeds'
+require 'discordrb/paginator'
 require 'time'
 require 'base64'
 

--- a/lib/discordrb/paginator.rb
+++ b/lib/discordrb/paginator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Discordrb
+  # Utility class for wrapping paginated endpoints. It is [Enumerable](https://ruby-doc.org/core-2.5.1/Enumerable.html),
+  # similar to an `Array`, so most of the same methods can be used to filter the results of the request
+  # that it wraps. If you simply want an array of all of the results, `#to_a` can be called.
+  class Paginator
+    include Enumerable
+
+    # Creates a new {Paginator}
+    # @param limit [Integer] the maximum number of items to request before stopping
+    # @param direction [:up, :down] the order in which results are returned in
+    # @yield [Array, nil] the last page of results, or nil if this is the first iteration.
+    #   This should be used to request the next page of results.
+    # @yieldreturn [Array] the next page of results
+    def initialize(limit, direction, &block)
+      @count = 0
+      @limit = limit
+      @direction = direction
+      @block = block
+    end
+
+    # Yields every item produced by the wrapped request, until it returns
+    # no more results or the configured `limit` is reached.
+    def each
+      last_page = nil
+      until limit_check
+        page = @block.call(last_page)
+        return if page.empty?
+
+        enumerator = if @direction == :down
+                       page.each
+                     elsif @direction == :up
+                       page.reverse_each
+                     end
+
+        enumerator.each do |item|
+          yield item
+          @count += 1
+          break if limit_check
+        end
+
+        last_page = page
+      end
+    end
+
+    private
+
+    # Whether the paginator limit has been exceeded
+    def limit_check
+      return false if @limit.nil?
+
+      @count >= @limit
+    end
+  end
+end

--- a/spec/paginator_spec.rb
+++ b/spec/paginator_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'discordrb'
+
+describe Discordrb::Paginator do
+  context 'direction down' do
+    it 'requests all pages until empty' do
+      data = [
+        [1, 2, 3],
+        [4, 5],
+        [],
+        [6, 7]
+      ]
+
+      index = 0
+      paginator = Discordrb::Paginator.new(nil, :down) do |last_page|
+        expect(last_page).to eq data[index - 1] if last_page
+        next_page = data[index]
+        index += 1
+        next_page
+      end
+
+      expect(paginator.to_a).to eq [1, 2, 3, 4, 5]
+    end
+  end
+
+  context 'direction up' do
+    it 'requests all pages until empty' do
+      data = [
+        [6, 7],
+        [4, 5],
+        [],
+        [1, 2, 3]
+      ]
+
+      index = 0
+      paginator = Discordrb::Paginator.new(nil, :up) do |last_page|
+        expect(last_page).to eq data[index - 1] if last_page
+        next_page = data[index]
+        index += 1
+        next_page
+      end
+
+      expect(paginator.to_a).to eq [7, 6, 5, 4]
+    end
+  end
+
+  it 'only returns up to limit items' do
+    data = [
+      [1, 2, 3],
+      [4, 5],
+      []
+    ]
+
+    index = 0
+    paginator = Discordrb::Paginator.new(2, :down) do |_last_page|
+      next_page = data[index]
+      index += 1
+      next_page
+    end
+
+    expect(paginator.to_a).to eq [1, 2]
+  end
+end


### PR DESCRIPTION
This PR adds `Paginator`, a utility class for wrapping paginated requests, and implements it right away in `Channel#history`. 

This primarily addresses the FAQ of users who want to retrieve more than 100 messages in a channel, and find it difficult to get the loop logic correct.

Now you can do this:

```rb
array = channel.history(1000).to_a
array.size #=> 1000
```

and discordrb will make as many requests as needed to fetch 1000 messages. Additionally you can pass `nil` to `amount` to fetch all of a channel's history in either direction.

`Paginator` is `Enumerable` so most methods you would already be using on `Array<Message>` will still work:

```rb
# Fetch the last 1000 messages, and select messages from z64
array = channel.history(1000).select do |message|
  message.author.name == "z64"
end
```

There are other requests we can use `Paginator` for, but those parts of the library aren't well prepared for that. They can be added in a later PR; `Channel#history` is the most used paginated endpoint.

## Compatibility

- `Channel#history` now takes named arguments. This is purely a personal vendetta, as I can never remember the order of the arguments. I can be persuaded to have both (named & positional) for a release, but I doubt I am the only one that has struggled with this, so I think this change is fine.

- If requesting 100 or fewer messages, or when using `around_id`, the behavior is the same; `Array<Message>` is returned. People who request more than 100 messages will get the new `Paginator`. Later I would like to always return a paginator, regardless.

- When using a `Paginator` request, messages are sorted *in the direction* of the request. Using `after_id` will return messages oldest to newest. Using `before_id` will return messages newest to oldest. I think it would be too complicated and slow to always return in the same order, as for one direction you would have to buffer every page before you could start giving messages to the user, who might not even need to request every page (i.e., they `break`). They primary use case for something like scraping large sections of history anyways should be for storing or updating a database of messages from downtime, in which the yielded order does not matter.

## (ex-) Guild Member Rate limiting

A last note is that when you roll over channel history that has messages from members that left the server, we will spam the API with requests for that member for each message encountered; this will indeed slow things down. We can avoid this, but the caching logic in `Message#initialize` is too complicated to change in one PR. I'm fine with leaving it as an optimization to make at a later date. Of course, this was already the case before this PR - but this PR makes that issue more efficiently exploited, so users may report it.