### PR TITLE
Fix Ruby version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 
 ## Dependencies
 
-* Ruby >= 2.3.7
+* Ruby >= 2.3
 * An installed build system for native extensions (on Windows for Ruby < 2.4, try the [DevKit](https://rubyinstaller.org/downloads/); installation instructions [here](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#quick-start) - you only need to do the quick start)
 
 > **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 
 ## Dependencies
 
-* Ruby 2.2+
+* Ruby >= 2.3.7
 * An installed build system for native extensions (on Windows for Ruby < 2.4, try the [DevKit](https://rubyinstaller.org/downloads/); installation instructions [here](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#quick-start) - you only need to do the quick start)
 
 > **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.


### PR DESCRIPTION
Just realized I forgot this in the previous PR :smiley: (#487)