### PR TITLE
Bump minimum Ruby version to 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Allow 'Pokémon-style' exception handling
 Lint/RescueException:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.3
+  - 2.4
+  - 2.5
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -21,7 +21,7 @@ deploy:
     local-dir: docs
     on:
       branch: master
-      rvm: 2.5.3
+      rvm: 2.5
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -29,4 +29,4 @@ deploy:
     local-dir: docs
     on:
       tags: true
-      rvm: 2.5.3
+      rvm: 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.4
   - 2.5
+  - 2.6
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -20,7 +21,7 @@ deploy:
     local-dir: docs
     on:
       branch: master
-      rvm: 2.5
+      rvm: 2.6
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -28,4 +29,4 @@ deploy:
     local-dir: docs
     on:
       tags: true
-      rvm: 2.5
+      rvm: 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -21,7 +21,7 @@ deploy:
     local-dir: docs
     on:
       branch: master
-      rvm: 2.5.1
+      rvm: 2.5.3
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -29,4 +29,4 @@ deploy:
     local-dir: docs
     on:
       tags: true
-      rvm: 2.5.1
+      rvm: 2.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Drop support for Ruby 2.3 (EOL) ([#583](https://github.com/meew0/discordrb/pull/583), thanks @PanisSupraOmnia)
 - **(breaking change)** Upgraded minimum Ruby version to 2.3.7, and upgraded Rubocop to 0.60.0. This additionally changes the name of some public constants. ([#487](https://github.com/meew0/discordrb/pull/487), thanks @ChallahuAkbar)
 - Dependencies for `rbnacl`, `rake`, and `rspec` have been updated ([#538](https://github.com/meew0/discordrb/pull/538), thanks @ChallahuAkbar)
 - The monolithic `data.rb` file has been split into multiple files for easier development ([#482](https://github.com/meew0/discordrb/pull/482))

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 
 ## Dependencies
 
-* Ruby >= 2.3
-* An installed build system for native extensions (on Windows for Ruby < 2.4, try the [DevKit](https://rubyinstaller.org/downloads/); installation instructions [here](https://github.com/oneclick/rubyinstaller/wiki/Development-Kit#quick-start) - you only need to do the quick start)
+* Ruby >= 2.4
+* An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 > **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See also: [Documentation](https://www.rubydoc.info/gems/discordrb), [Tutorials](
 
 ## Dependencies
 
-* Ruby >= 2.4
+* Ruby >= 2.4 supported
 * An installed build system for native extensions (on Windows, make sure you download the "Ruby+Devkit" version of [RubyInstaller](https://rubyinstaller.org/downloads/))
 
 > **Note:** RubyInstaller for Ruby versions 2.4+ will install the DevKit as the last step of the installation.

--- a/README.md
+++ b/README.md
@@ -92,26 +92,11 @@ Select option 3, and then run
 
 To enable the changes
 
-##### RubyInstaller for ruby 2.3.3 and below
-
-Download the development kit [here](https://rubyinstaller.org/downloads/) (scroll down to "Development Kit", then choose the one for Ruby 2.0 and your system architecture) and extract it somewhere. Open a command prompt in that folder and run:
-
-    ruby dk.rb init
-    ruby dk.rb install
-
-Then reinstall discordrb:
-
-    gem uninstall discordrb
-    bundle install
-
-    # Or, if you didn't use bundler:
-    gem install discordrb
-
 **If Ruby complains about `ffi_c` not being able to be found:**
 
 For example
 
-    C:/Ruby23-x64/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- ffi_c (LoadError)
+    C:/Ruby25-x64/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- ffi_c (LoadError)
 
 Your ffi setup is screwed up, first run `gem uninstall ffi` (uninstall all versions if it asks you, say yes to any unmet dependencies), then run `gem install ffi --platform=ruby` to fix it. If it says something about build tools, follow the steps in the first troubleshooting section.
 

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 end

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
 
-  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_ruby_version = '>= 2.3'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'
 
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rbnacl', '>= 5.0'
+  spec.add_dependency 'rbnacl', '~> 6.0'
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.60.0'
+  spec.add_development_dependency 'rubocop', '~> 0.60'
   spec.add_development_dependency 'simplecov', '~> 0.16.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rbnacl', '~> 5.0'
+  spec.add_dependency 'rbnacl', '>= 5.0'
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'
 
-  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/lib/discordrb/voice/voice_bot.rb
+++ b/lib/discordrb/voice/voice_bot.rb
@@ -262,7 +262,7 @@ module Discordrb::Voice
       raise ArgumentError, 'Not a DCA1 file! The file might have been corrupted, please recreate it.' unless magic == 'DCA1'
 
       # Read the metadata header, then read the metadata and discard it as we don't care about it
-      metadata_header = input_stream.read(4).unpack('l<')[0]
+      metadata_header = input_stream.read(4).unpack1('l<')
       input_stream.read(metadata_header)
 
       # Play the data, without re-encoding it to opus
@@ -276,7 +276,7 @@ module Discordrb::Voice
             next :stop
           end
 
-          header = header_str.unpack('s<')[0]
+          header = header_str.unpack1('s<')
 
           raise 'Negative header in DCA file! Your file is likely corrupted.' if header.negative?
         rescue EOFError


### PR DESCRIPTION
This PR is for when we're ready to bump the minimum Ruby version to 2.4. This shouldn't be _all_ that soon, but Ruby 2.3 reaches EOL next March, so it's not too far away.