### PR TITLE
Upgrade rest-client using a Ruby native extension on Windows

### DIFF
--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.extensions << 'ext/mkrf_conf.rb'
 
-  spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
+  spec.add_dependency 'rest-client', '~> 2.0'
 
   spec.required_ruby_version = '>= 2.3.7'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
+  spec.add_dependency 'rake', '~> 12.0'
   spec.add_dependency 'rbnacl', '~> 5.0'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
@@ -35,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.3.7'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -22,11 +22,12 @@ Gem::Specification.new do |spec|
     'changelog_uri' => 'https://github.com/meew0/discordrb/blob/master/CHANGELOG.md'
   }
   spec.require_paths = ['lib']
+  spec.extensions << 'ext/mkrf_conf.rb'
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
   spec.add_dependency 'rbnacl', '~> 5.0'
-  spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
+  spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rubygems'
+require 'rubygems/command'
+require 'rubygems/dependency_installer'
+
+Gem::Command.build_args = ARGV
+
+installer = Gem::DependencyInstaller.new
+begin
+  if RUBY_VERSION >= '2.5.0' && Gem.win_platform?
+    puts 'Installing on Ruby >= 2.5.0 on a Windows OS, so rest-client ~> 2.1.0.rc1 will be used'
+    installer.install 'rest-client', '~> 2.1.0.rc1'
+  else
+    installer.install 'rest-client', '~> 2.0'
+  end
+rescue StandardError
+  exit(1)
+end
+
+# Create dummy rakefile to indicate success
+path = File.join(File.dirname(__FILE__), 'Rakefile')
+File.open(path, 'w') do |file|
+  file.write("task :default\n")
+end


### PR DESCRIPTION
Another follow up to #478.

This PR:

- Creates a pure Ruby native extension for an install-time hook to install the rest-client release client specifically on Ruby 2.5 on Windows
- Moves back to `~> 2.0` for "everyone else"
- Makes `rake` a regular dependency. For some reason this is needed. Other libraries/apps with custom native extensions need this too... I'm not against it - who doesn't love Rake - but it would be nice to know why.

Also supports certain downstream users over at GitLab: https://gitlab.com/gitlab-org/gitlab-ce/issues/53890

I've only tested this on Linux. I'll get to trying it on Windows eventually, but if someone else could verify that would be fantastic.

To test this, you just need to make a new directory with a `Gemfile`:
```rb
source 'https://rubygems.org'
gem 'discordrb', git: 'https://github.com/z64/discordrb', branch: 'rest-client-win'
```
and run:
1. `bundle install --path vendor/bundle --binstubs`
2. `bundle exec ruby -e 'require "discordrb"; p RestClient::VERSION'`

Reviews welcome as well. I don't know what I'm doing here 😄 ❤️ 