### PR TITLE
Update deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.3
+  - 2.3
+  - 2.4
+  - 2.5
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -21,7 +21,7 @@ deploy:
     local-dir: docs
     on:
       branch: master
-      rvm: 2.5.3
+      rvm: 2.5
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -29,4 +29,4 @@ deploy:
     local-dir: docs
     on:
       tags: true
-      rvm: 2.5.3
+      rvm: 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.1
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -o ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -21,7 +21,7 @@ deploy:
     local-dir: docs
     on:
       branch: master
-      rvm: 2.5.1
+      rvm: 2.5.3
   - provider: pages
     skip-cleanup: true
     github-token: $GITHUB_TOKEN
@@ -29,4 +29,4 @@ deploy:
     local-dir: docs
     on:
       tags: true
-      rvm: 2.5.1
+      rvm: 2.5.3

--- a/discordrb-webhooks.gemspec
+++ b/discordrb-webhooks.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
 
-  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_ruby_version = '>= 2.3'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rbnacl', '>= 5.0'
+  spec.add_dependency 'rbnacl', '~> 6.0'
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.60.0'
+  spec.add_development_dependency 'rubocop', '~> 0.60'
   spec.add_development_dependency 'simplecov', '~> 0.16.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
 end

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'ffi', '>= 1.9.24'
   spec.add_dependency 'opus-ruby'
-  spec.add_dependency 'rbnacl', '~> 5.0'
+  spec.add_dependency 'rbnacl', '>= 5.0'
   spec.add_dependency 'rest-client', '>= 2.1.0.rc1'
   spec.add_dependency 'websocket-client-simple', '>= 0.3.0'
 
   spec.add_dependency 'discordrb-webhooks', '~> 3.3.0'
 
-  spec.required_ruby_version = '>= 2.3.7'
+  spec.required_ruby_version = '>= 2.3'
 
   spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
# Summary

General version housekeeping. I loosened the RbNaCl version so that 6.0 could be picked up, made it so we only depend on major.minor Ruby versions (per [previous comment](https://github.com/meew0/discordrb/pull/582#discussion_r229126140)), and bumped Ruby versions in Travis.

---

## Changed

- Bump RbNaCl version
- Loosen RuboCop version restriction
- Remove teeny version from Ruby version restriction