### PR TITLE
Add MessageEvent#await!

### DIFF
--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -139,6 +139,12 @@ module Discordrb::Events
       @file = nil
     end
 
+    # Add a blocking {Await} for a message with the same message author and channel.
+    # @see Bot#add_await!,
+    def await!(attributes = {})
+      @bot.add_await!(Discordrb::Events::MessageEvent, { from: @message.author.id, in: @channel.id }.merge(attributes))
+    end
+
     # @return [true, false] whether or not this message was sent by the bot itself
     def from_bot?
       @message.user.id == @bot.profile.id


### PR DESCRIPTION
```ruby
bot.command :test do |event|
  # before
  res = event.message.await!
  # after
  res = event.await!
end
```

I didn't add `MessageEvent#await`. The reason is `await` will be deprecated.
