### PR TITLE
Fix Travis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **(breaking change)** Upgraded minimum Ruby version to 2.3.7, and upgraded Rubocop to 0.60.0. This additionally changes the name of some public constants. ([#487](https://github.com/meew0/discordrb/pull/487), thanks @ChallahuAkbar)
 - Dependencies for `rbnacl`, `rake`, and `rspec` have been updated ([#538](https://github.com/meew0/discordrb/pull/538), thanks @ChallahuAkbar)
 - The monolithic `data.rb` file has been split into multiple files for easier development ([#482](https://github.com/meew0/discordrb/pull/482))
+- Loosened `bundler` development dependency to allow use of `bundler` 1.x and 2.x ([#591](https://github.com/meew0/discordrb/pull/591), thanks ChallahuAkbar)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.7'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '>= 1.10', '< 3'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'


### PR DESCRIPTION
# Summary

Due to Bundler 2.0 shenanigans, Travis was failing; loosening the development dependency on Bundler fixes it.

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Fixed

- Fixed Travis build by loosening Bundler dependency to allow both 1.x and 2.x versions.