### PR TITLE
Adding position to API::Server.create_channel and Server.create_channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dependencies for `rbnacl`, `rake`, and `rspec` have been updated ([#538](https://github.com/meew0/discordrb/pull/538), thanks @ChallahuAkbar)
 - The monolithic `data.rb` file has been split into multiple files for easier development ([#482](https://github.com/meew0/discordrb/pull/482))
 - Loosened `bundler` development dependency to allow use of `bundler` 1.x and 2.x ([#591](https://github.com/meew0/discordrb/pull/591), thanks ChallahuAkbar)
+- `API::Server.create_channel` and `Server#create_channel` now accepts `position` ([#592](https://github.com/meew0/discordrb/pull/592), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -85,13 +85,13 @@ module Discordrb::API::Server
 
   # Create a channel
   # https://discordapp.com/developers/docs/resources/guild#create-guild-channel
-  def create_channel(token, server_id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, reason = nil)
+  def create_channel(token, server_id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason = nil)
     Discordrb::API.request(
       :guilds_sid_channels,
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user }.to_json,
+      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user, position: position }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -456,13 +456,13 @@ module Discordrb
     # @param reason [String] The reason the for the creation of this channel.
     # @return [Channel] the created channel.
     # @raise [ArgumentError] if type is not 0 (text), 2 (voice), or 4 (category)
-    def create_channel(name, type = 0, topic: nil, bitrate: nil, user_limit: nil, permission_overwrites: nil, parent: nil, nsfw: false, rate_limit_per_user: nil, reason: nil)
+    def create_channel(name, type = 0, topic: nil, bitrate: nil, user_limit: nil, permission_overwrites: nil, parent: nil, nsfw: false, rate_limit_per_user: nil, position: nil, reason: nil)
       type = Channel::TYPES[type] if type.is_a?(Symbol)
       raise ArgumentError, 'Channel type must be either 0 (text), 2 (voice), or 4 (category)!' unless [0, 2, 4].include?(type)
 
       permission_overwrites.map! { |e| e.is_a?(Overwrite) ? e.to_hash : e } if permission_overwrites.is_a?(Array)
       parent_id = parent.respond_to?(:resolve_id) ? parent.resolve_id : nil
-      response = API::Server.create_channel(@bot.token, @id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, reason)
+      response = API::Server.create_channel(@bot.token, @id, name, type, topic, bitrate, user_limit, permission_overwrites, parent_id, nsfw, rate_limit_per_user, position, reason)
       Channel.new(JSON.parse(response), @bot)
     end
 


### PR DESCRIPTION
# Summary

Added support for `position` in channel creation. From request #584.

This PR assumes that we are just setting the position as allowed by the API and not shifting
other channels to make an absolute placement in the list.
 

## Changed

`Server.create_channel` - added position as named argument

`API::Server.create_channel` - added position as argument before optional argument `reason`.
