### PR TITLE
Validate bot token using API.gateway_bot before connecting

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -290,6 +290,18 @@ module Discordrb::API
     )
   end
 
+  # Get the gateway to be used, with additional information for sharding and
+  # session start limits
+  def gateway_bot(token)
+    request(
+      :gateway_bot,
+      nil,
+      :get,
+      "#{api_base}/gateway/bot",
+      Authorization: token
+    )
+  end
+
   # Validate a token (this request will fail if the token is invalid)
   def validate_token(token)
     request(

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -62,6 +62,10 @@ module Discordrb
     # @return [Gateway] the underlying {Gateway} object.
     attr_reader :gateway
 
+    # @return [Symbol] the type of bot, either `:bot` or `:user`
+    # !@visibility private
+    attr_reader :type
+
     include EventContainer
     include Cache
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -521,8 +521,23 @@ module Discordrb
     end
 
     def find_gateway
-      response = API.gateway(@token)
-      JSON.parse(response)['url']
+      response = nil
+      if @bot.type == :bot
+        begin
+          response = JSON.parse(API.gateway_bot(@token))
+          sessions = response['session_start_limit']
+          LOGGER.debug("Found gateway URL: #{response['url']}")
+          LOGGER.debug("Sessions remaining: #{sessions['remaining']} / #{sessions['total']}")
+        rescue StandardError => ex
+          LOGGER.error("Failed to get gateway URL! This means your token is incorrect, or Discord couldn't be reached.")
+          LOGGER.log_exception(ex)
+          # There's nothing we can do - the token cannot be corrected at runtime.
+          exit(1)
+        end
+      else
+        response = JSON.parse(API.gateway(@token))
+      end
+      response['url']
     end
 
     def process_gateway


### PR DESCRIPTION
This uses the authenticated `API.gateway_bot` endpoint to retrieve the gateway URL in `Gateway#find_gateway`. If this step fails with an uncaught exception, and we cannot retrieve a gateway URL, this is because the bot's token is incorrect. The token can not be corrected at runtime, so we abort the connection process.

`Bot#type` is exposed to be used internally to decide if we should validate the token in this manner.