### PR TITLE
Add Discordrb::Server#add_emoji and add roles parameter to Discordrb:…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue and pull request templates ([#585](https://github.com/meew0/discordrb/pull/585))
 - `Server#bot` method for obtaining your bot's own `Member` on a particular server ([#597](https://github.com/meew0/discordrb/pull/597))
 - `Attachment#spoiler?`, to check if an attachment is a spoiler or not ([#603](https://github.com/meew0/discordrb/pull/603), thanks @swarley)
+- Methods on `Server` to manage the server's emoji ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Bot.new` will now raise a more helpful exception when the passed token string is empty or nil ([#599](https://github.com/meew0/discordrb/pull/599))
 - `compress_mode` in `Bot.new` now defaults to `:large` instead of `:stream` ([#601](https://github.com/meew0/discordrb/pull/601))
 - `send_file` methods now accept `filename` to rename a file when uploading to Discord ([#605](https://github.com/meew0/discordrb/pull/605), thanks @swarley)
+- Emoji related `API` methods now accept arguments to change an emoji's role whitelist ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -453,13 +453,13 @@ module Discordrb::API::Server
   end
 
   # Adds a custom emoji
-  def add_emoji(token, server_id, image, name, reason = nil)
+  def add_emoji(token, server_id, image, name, roles = [], reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis,
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/emojis",
-      { image: image, name: name }.to_json,
+      { image: image, name: name, roles: roles }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -452,7 +452,8 @@ module Discordrb::API::Server
     )
   end
 
-  # Adds a custom emoji
+  # Adds a custom emoji.
+  # https://discordapp.com/developers/docs/resources/emoji#create-guild-emoji
   def add_emoji(token, server_id, image, name, roles = [], reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis,
@@ -466,7 +467,8 @@ module Discordrb::API::Server
     )
   end
 
-  # Changes an emoji name
+  # Changes an emoji name and/or roles.
+  # https://discordapp.com/developers/docs/resources/emoji#modify-guild-emoji
   def edit_emoji(token, server_id, emoji_id, name, roles = nil, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -467,13 +467,13 @@ module Discordrb::API::Server
   end
 
   # Changes an emoji name
-  def edit_emoji(token, server_id, emoji_id, name, reason = nil)
+  def edit_emoji(token, server_id, emoji_id, name, roles = nil, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/emojis/#{emoji_id}",
-      { name: name }.to_json,
+      { name: name, roles: roles }.to_json,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -483,6 +483,7 @@ module Discordrb::API::Server
   end
 
   # Deletes a custom emoji
+  # https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji
   def delete_emoji(token, server_id, emoji_id, reason = nil)
     Discordrb::API.request(
       :guilds_sid_emojis_eid,

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -499,12 +499,12 @@ module Discordrb
       role
     end
 
-    # Add a new custom emoji on this server.
+    # Adds a new custom emoji on this server.
     # @param name [String] The name of emoji to create.
     # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`, such as `File`.
     # @param roles [Array<Role, String, Integer>] An array of roles, or role IDs to be whitelisted for this emoji.
-    # @param reason [String] The reason the for the creation of this channel.
-    # @return [Emoji] The Emoji that has been added.
+    # @param reason [String] The reason the for the creation of this emoji.
+    # @return [Emoji] The emoji that has been added.
     def add_emoji(name, image, roles = [], reason: nil)
       image_string = image
       if image.respond_to? :read
@@ -524,10 +524,11 @@ module Discordrb
       API::Server.delete_emoji(@bot.token, @id, emoji.resolve_id, reason)
     end
 
-    # Change the name and/or whitelist of an emoji on this server.
-    # @param emoji [Emoji, Integer, String] The emoji to edit.
+    # Changes the name and/or role whitelist of an emoji on this server.
+    # @param emoji [Emoji, Integer, String] The emoji or emoji ID to edit.
     # @param name [String] The new name for the emoji.
     # @param roles [Array<Role, Integer, String>] A new array of roles, or role IDs, to whitelist.
+    # @param reason [String] The reason for the editing of this emoji.
     # @return [Emoji] The edited emoji.
     def edit_emoji(emoji, name: nil, roles: nil, reason: nil)
       emoji = @emoji[emoji.resolve_id]

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -499,11 +499,12 @@ module Discordrb
       role
     end
 
+    # Add a new custom emoji on this server.
     # @param name [String] The name of emoji to create.
     # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`.
     # @param roles [Array<Role, String, Integer>] An array of roles, or role IDs to be whitelisted for this emoji.
     # @param reason [String] The reason the for the creation of this channel.
-    # @returns [Emoji] The Emoji that has been added.
+    # @return [Emoji] The Emoji that has been added.
     def add_emoji(name, image, roles = [], reason = nil)
       image_string = image
       if image.respond_to? :read
@@ -513,6 +514,17 @@ module Discordrb
 
       response = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
       @emoji[response['id'].to_i]
+    end
+
+    # Change the name and/or whitelist of an emoji on this server.
+    # @param emoji [Emoji, String, Integer] The emoji to edit.
+    # @param name [String] The new name for the emoji.
+    # @param roles [Array<Role, Integer, String>] A new array of roles, or role IDs, to whitelist.
+    # @return [Emoji] The edited emoji.
+    def edit_emoji(emoji, name: nil, roles: nil, reason: nil)
+      emoji = @emoji[emoji.resolve_id]
+      API::Server.edit_emoji(@bot.token, @id, emoji.resolve_id, name || emoji.name, (roles || emoji.roles).map(&:resolve_id), reason)
+      emoji
     end
 
     # @return [Array<ServerBan>] a list of banned users on this server and the reason they were banned.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -518,7 +518,7 @@ module Discordrb
     end
 
     # Delete a custom emoji on this server
-    # @param emoji [Emoji, Integer, String]
+    # @param emoji [Emoji, Integer, String] The emoji or emoji ID to be deleted.
     # @param reason [String] The reason the for the deletion of this emoji.
     def delete_emoji(emoji, reason: nil)
       API::Server.delete_emoji(@bot.token, @id, emoji.resolve_id, reason)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -517,8 +517,15 @@ module Discordrb
       @emoji[new_emoji.id] = new_emoji
     end
 
+    # Delete a custom emoji on this server
+    # @param emoji [Emoji, Integer, String]
+    # @param reason [String] The reason the for the deletion of this emoji.
+    def delete_emoji(emoji, reason: nil)
+      API::Server.delete_emoji(@bot.token, @id, emoji.resolve_id, reason)
+    end
+
     # Change the name and/or whitelist of an emoji on this server.
-    # @param emoji [Emoji, String, Integer] The emoji to edit.
+    # @param emoji [Emoji, Integer, String] The emoji to edit.
     # @param name [String] The new name for the emoji.
     # @param roles [Array<Role, Integer, String>] A new array of roles, or role IDs, to whitelist.
     # @return [Emoji] The edited emoji.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -501,19 +501,20 @@ module Discordrb
 
     # Add a new custom emoji on this server.
     # @param name [String] The name of emoji to create.
-    # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`.
+    # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`, such as `File`.
     # @param roles [Array<Role, String, Integer>] An array of roles, or role IDs to be whitelisted for this emoji.
     # @param reason [String] The reason the for the creation of this channel.
     # @return [Emoji] The Emoji that has been added.
-    def add_emoji(name, image, roles = [], reason = nil)
+    def add_emoji(name, image, roles = [], reason: nil)
       image_string = image
       if image.respond_to? :read
         image_string = 'data:image/jpg;base64,'
         image_string += Base64.strict_encode64(image.read)
       end
 
-      response = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
-      @emoji[response['id'].to_i]
+      data = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
+      new_emoji = Emoji.new(data)
+      @emoji[new_emoji.id] = new_emoji
     end
 
     # Change the name and/or whitelist of an emoji on this server.
@@ -523,8 +524,9 @@ module Discordrb
     # @return [Emoji] The edited emoji.
     def edit_emoji(emoji, name: nil, roles: nil, reason: nil)
       emoji = @emoji[emoji.resolve_id]
-      API::Server.edit_emoji(@bot.token, @id, emoji.resolve_id, name || emoji.name, (roles || emoji.roles).map(&:resolve_id), reason)
-      emoji
+      data = JSON.parse(API::Server.edit_emoji(@bot.token, @id, emoji.resolve_id, name || emoji.name, (roles || emoji.roles).map(&:resolve_id), reason))
+      new_emoji = Emoji.new(data)
+      @emoji[new_emoji.id] = new_emoji
     end
 
     # @return [Array<ServerBan>] a list of banned users on this server and the reason they were banned.

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -499,6 +499,22 @@ module Discordrb
       role
     end
 
+    # @param name [String] The name of emoji to create.
+    # @param image [String, #read] A base64 encoded string with the image data, or an object that responds to `#read`.
+    # @param roles [Array<Role, String, Integer>] An array of roles, or role IDs to be whitelisted for this emoji.
+    # @param reason [String] The reason the for the creation of this channel.
+    # @returns [Emoji] The Emoji that has been added.
+    def add_emoji(name, image, roles = [], reason = nil)
+      image_string = image
+      if image.respond_to? :read
+        image_string = 'data:image/jpg;base64,'
+        image_string += Base64.strict_encode64(image.read)
+      end
+
+      response = JSON.parse(API::Server.add_emoji(@bot.token, @id, image_string, name, roles.map(&:resolve_id), reason))
+      @emoji[response['id'].to_i]
+    end
+
     # @return [Array<ServerBan>] a list of banned users on this server and the reason they were banned.
     def bans
       response = JSON.parse(API::Server.bans(@bot.token, @id))


### PR DESCRIPTION
…:API::Server.add_emoji

# Summary

In reference to issue #470 

Adds a `Server` instance method for adding a custom guild emoji. Implements `API::Server.add_emoji`. Also adds the `roles` whitelist parameter to `API::Server.add_emoji`.

---

## Added

`Discordrb::Server#add_emoji(name, image, roles=[], reason=nil)` - returns `Emoji` object of added emoji.


## Changed

`Discordrb::API::Server.add_emoji()` - added optional param `roles` before `reason` param.

