### PR TITLE
Fix custom emoji reactions with the same name from being discarded

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -38,7 +38,7 @@ module Discordrb
     # @return [Array<Embed>] the embed objects contained in this message.
     attr_reader :embeds
 
-    # @return [Hash<String => Reaction>] the reaction objects attached to this message keyed by the name of the reaction
+    # @return [Array<Reaction>] the reaction objects contained in this message.
     attr_reader :reactions
 
     # @return [true, false] whether the message used Text-To-Speech (TTS) or not.
@@ -108,10 +108,10 @@ module Discordrb
 
       @emoji = []
 
-      @reactions = {}
+      @reactions = []
 
       data['reactions']&.each do |element|
-        @reactions[element['emoji']['name']] = Reaction.new(element)
+        @reactions << Reaction.new(element)
       end
 
       @mentions = []
@@ -230,7 +230,7 @@ module Discordrb
     # Returns the reactions made by the current bot or user.
     # @return [Array<Reaction>] the reactions
     def my_reactions
-      @reactions.values.select(&:me)
+      @reactions.select(&:me)
     end
 
     # Reacts to a message.

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -224,7 +224,7 @@ module Discordrb
     # Check if any reactions were used in this message.
     # @return [true, false] whether or not this message has reactions
     def reactions?
-      @reactions.any?
+      @reactions.empty?
     end
 
     # Returns the reactions made by the current bot or user.


### PR DESCRIPTION
Basically reverts 21a7e8d. See commit messages for more details. Snuck in a small performance change that bothered me #YoLO

We may restore a similarly intended API such as `Message#reaction(emoji)` in a later change. If that doesn't get released, the workaround is to explicitly use `Enumerable#select`, `#find`, etc.