### PR TITLE
Add Server#bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Bot#parse_mentions`, which extracts *all* mentions found in a string ([#526](https://github.com/meew0/discordrb/pull/526), thanks @SanksTheYokai)
 - Issue and pull request templates ([#585](https://github.com/meew0/discordrb/pull/585))
+- `Server#bot` method for obtaining your bot's own `Member` on a particular server ([#597](https://github.com/meew0/discordrb/pull/597))
 
 ### Changed
 

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -142,6 +142,11 @@ module Discordrb
 
     alias_method :users, :members
 
+    # @return [Member] the bot's own `Member` on this server
+    def bot
+      member(@bot.profile)
+    end
+
     # @return [Array<Integration>] an array of all the integrations connected to this server.
     def integrations
       integration = JSON.parse(API::Server.integrations(@bot.token, @id))


### PR DESCRIPTION
This allows for easier managing of the bot's own member on the given server for common tasks such as:

Changing the bots own nickname:

    server.bot.nick = "new nick"

Managing the bots own roles:

    server.bot.add_role(role)

Previously, one would have to do something such as `server.member(bot.profile)` or `bot.profile.on(server)`, which can be confusing or a point of inconsistency in a codebase.