### PR TITLE
Change default gateway compression mode to :large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Loosened `bundler` development dependency to allow use of `bundler` 1.x and 2.x ([#591](https://github.com/meew0/discordrb/pull/591), thanks ChallahuAkbar)
 - `API::Server.create_channel` and `Server#create_channel` now accepts `position` ([#592](https://github.com/meew0/discordrb/pull/592), thanks @swarley)
 - `Bot.new` will now raise a more helpful exception when the passed token string is empty or nil ([#599](https://github.com/meew0/discordrb/pull/599))
+- `compress_mode` in `Bot.new` now defaults to `:large` instead of `:stream` ([#601](https://github.com/meew0/discordrb/pull/601))
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -106,7 +106,7 @@ module Discordrb
         token: nil, client_id: nil,
         type: nil, name: '', fancy_log: false, suppress_ready: false, parse_self: false,
         shard_id: nil, num_shards: nil, redact_token: true, ignore_bots: false,
-        compress_mode: :stream
+        compress_mode: :large
       )
       LOGGER.mode = log_mode
       LOGGER.token = token if redact_token


### PR DESCRIPTION
This reverts the default compression mode to `:large` due to `:stream` being a slow codepath, causing slowness / instability in bots.

See #600 for more details.