### PR TITLE
send_file filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `API::Server.create_channel` and `Server#create_channel` now accepts `position` ([#592](https://github.com/meew0/discordrb/pull/592), thanks @swarley)
 - `Bot.new` will now raise a more helpful exception when the passed token string is empty or nil ([#599](https://github.com/meew0/discordrb/pull/599))
 - `compress_mode` in `Bot.new` now defaults to `:large` instead of `:stream` ([#601](https://github.com/meew0/discordrb/pull/601))
+- `send_file` methods now accept `filename` to rename a file when uploading to Discord ([#605](https://github.com/meew0/discordrb/pull/605), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -396,9 +396,13 @@ module Discordrb
     # @param file [File] The file that should be sent.
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
+    # @param filename [String] Overrides the filename of the uploaded file
     # @example Send a file from disk
     #   bot.send_file(83281822225530880, File.open('rubytaco.png', 'r'))
-    def send_file(channel, file, caption: nil, tts: false)
+    def send_file(channel, file, caption: nil, tts: false, filename: nil)
+      # https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/payload.rb#L160
+      file.define_singleton_method(:original_filename) { filename } if file.respond_to?(:read) && filename
+
       channel = channel.resolve_id
       response = API::Channel.upload_file(token, channel, file, caption: caption, tts: tts)
       Message.new(JSON.parse(response), self)

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -374,10 +374,11 @@ module Discordrb
     # @param file [File] The file to send. There's no clear size limit for this, you'll have to attempt it for yourself (most non-image files are fine, large images may fail to embed)
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
+    # @param filename [String] Overrides the filename of the uploaded file
     # @example Send a file from disk
     #   channel.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption: nil, tts: false)
-      @bot.send_file(@id, file, caption: caption, tts: tts)
+    def send_file(file, caption: nil, tts: false, filename: nil)
+      @bot.send_file(@id, file, caption: caption, tts: tts, filename: filename)
     end
 
     # Deletes a message on this channel. Mostly useful in case a message needs to be deleted when only the ID is known

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -100,11 +100,12 @@ module Discordrb
     # Send the user a file.
     # @param file [File] The file to send to the user
     # @param caption [String] The caption of the file being sent
+    # @param filename [String] Overrides the filename of the uploaded file
     # @return [Message] the message sent to this user.
     # @example Send a file from disk
     #   user.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption = nil)
-      pm.send_file(file, caption: caption)
+    def send_file(file, caption = nil, filename: nil)
+      pm.send_file(file, caption: caption, filename: filename)
     end
 
     # Set the user's name

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -82,8 +82,11 @@ module Discordrb::Events
     # @return [String] the message that has been saved by calls to {#<<} and will be sent to Discord upon completion.
     attr_reader :saved_message
 
-    # @return [File] the file that have been saved by calls to {#attach_file} and will be sent to Discord upon completion.
+    # @return [File] the file that has been saved by a call to {#attach_file} and will be sent to Discord upon completion.
     attr_reader :file
+
+    # @return [String] the filename set in {#attach_file} that will override the original filename when sent.
+    attr_reader :filename
 
     # @!attribute [r] author
     #   @return [Member, User] who sent this message.
@@ -110,6 +113,7 @@ module Discordrb::Events
       @channel = message.channel
       @saved_message = ''
       @file = nil
+      @filename = nil
     end
 
     # Sends file with a caption to the channel this message was sent in, right now.
@@ -133,13 +137,14 @@ module Discordrb::Events
       raise ArgumentError, 'Argument is not a file!' unless file.is_a?(File)
 
       @file = file
-      @file.define_singleton_method(:original_filename) { filename } if file.respond_to?(:read) && filename
+      @filename = filename
       nil
     end
 
     # Detaches a file from the message event.
     def detach_file
       @file = nil
+      @filename = nil
     end
 
     # @return [true, false] whether or not this message was sent by the bot itself
@@ -225,7 +230,7 @@ module Discordrb::Events
       if event.file.nil?
         event.send_message(event.saved_message) unless event.saved_message.empty?
       else
-        event.send_file(event.file, caption: event.saved_message)
+        event.send_file(event.file, caption: event.saved_message, filename: event.filename)
       end
     end
   end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -133,7 +133,7 @@ module Discordrb::Events
       raise ArgumentError, 'Argument is not a file!' unless file.is_a?(File)
 
       @file = file
-      @file.define_singleton_method(:original_filename) { filename }
+      @file.define_singleton_method(:original_filename) { filename } if file.respond_to?(:read) && filename
       nil
     end
 

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -117,20 +117,23 @@ module Discordrb::Events
     # because it avoids rate limiting problems
     # @param file [File] The file to send to the channel
     # @param caption [String] The caption attached to the file
+    # @param filename [String] Overrides the filename of the uploaded file
     # @return [Discordrb::Message] the message that was sent
     # @example Send a file from disk
     #   event.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption: nil)
-      @message.channel.send_file(file, caption: caption)
+    def send_file(file, caption: nil, filename: nil)
+      @message.channel.send_file(file, caption: caption, filename: filename)
     end
 
     # Attaches a file to the message event and converts the message into
     # a caption.
     # @param file [File] The file to be attached
-    def attach_file(file)
+    # @param filename [String] Overrides the filename of the uploaded file
+    def attach_file(file, filename: nil)
       raise ArgumentError, 'Argument is not a file!' unless file.is_a?(File)
 
       @file = file
+      @file.define_singleton_method(:original_filename) { filename }
       nil
     end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -143,28 +143,29 @@ describe Discordrb::Bot do
   end
 
   describe '#send_file' do
-    it 'defines an original_filename singleton when filename is passed' do
-      file = double(:file)
-      filename = double(:filename)
+    let(:channel) { double(:channel, resolve_id: double) }
 
-      allow(file).to receive(:respond_to?).with(:read).and_return(true)
+    it 'defines an original_filename singleton when filename is passed' do
+      original_filename = double(:original_filename)
+      file = double(:file, original_filename: original_filename, read: true)
+      new_filename = double('new filename')
+
       allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
 
-      bot.send_file(0, file, filename: filename)
-
-      expect(file.original_filename).to eq filename
+      bot.send_file(channel, file, filename: new_filename)
+      expect(file.original_filename).to eq new_filename
     end
 
     it 'does not define original_filename when filename is nil' do
-      file = double(:file)
+      original_filename = double(:original_filename)
+      file = double(:file, read: true, original_filename: original_filename)
 
-      allow(file).to receive(:respond_to?).with(:read).and_return(true)
       allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
 
-      expect(file).not_to receive(:define_singleton_method)
-      bot.send_file(0, file)
+      bot.send_file(channel, file)
+      expect(file.original_filename).to eq original_filename
     end
   end
 end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -141,4 +141,30 @@ describe Discordrb::Bot do
       expect(emoji.roles).to eq([])
     end
   end
+
+  describe '#send_file' do
+    it 'defines an original_filename singleton when filename is passed' do
+      file = double(:file)
+      filename = double(:filename)
+
+      allow(file).to receive(:respond_to?).with(:read).and_return(true)
+      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
+      allow(Discordrb::Message).to receive(:new)
+
+      bot.send_file(0, file, filename: filename)
+
+      expect(file.original_filename).to eq filename
+    end
+
+    it 'does not define original_filename when filename is nil' do
+      file = double(:file)
+
+      allow(file).to receive(:respond_to?).with(:read).and_return(true)
+      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
+      allow(Discordrb::Message).to receive(:new)
+
+      expect(file).not_to receive(:define_singleton_method)
+      bot.send_file(0, file)
+    end
+  end
 end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -145,7 +145,7 @@ describe Discordrb::Bot do
   describe '#send_file' do
     let(:channel) { double(:channel, resolve_id: double) }
 
-    it 'defines an original_filename singleton when filename is passed' do
+    it 'defines original_filename when filename is passed' do
       original_filename = double(:original_filename)
       file = double(:file, original_filename: original_filename, read: true)
       new_filename = double('new filename')

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -119,7 +119,7 @@ describe Discordrb::Events do
         filename = double(:filename)
         allow(file).to receive(:is_a?).with(File).and_return(true)
 
-        expect(event).to receive(:send_file).with(file, caption: '', filename: new_filename)
+        expect(event).to receive(:send_file).with(file, caption: '', filename: filename)
         event.attach_file(file, filename: filename)
         handler.after_call(event)
       end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -109,31 +109,18 @@ describe Discordrb::Events do
       described_class.new(message, bot)
     end
 
-    describe '#attach_file' do
+    describe 'after_call' do
       subject :handler do
         Discordrb::Events::MessageEventHandler.new(double, double('proc'))
       end
 
-      it 'defines an original_filename singleton when filename is passed' do
-        original_filename = double(:filename)
-        file = double(:file, original_filename: original_filename, read: true)
-        new_filename = double('new filename')
-
+      it 'calls send_file with attached file and filename' do
+        file = double(:file)
+        filename = double(:filename)
         allow(file).to receive(:is_a?).with(File).and_return(true)
 
-        event.attach_file(file, filename: new_filename)
         expect(event).to receive(:send_file).with(file, caption: '', filename: new_filename)
-        handler.after_call(event)
-      end
-
-      it 'does not define original_filename when filename is nil' do
-        original_filename = double(:filename)
-        file = double(:file, original_filename: original_filename, read: true)
-
-        allow(file).to receive(:is_a?).with(File).and_return(true)
-
-        event.attach_file(file)
-        expect(event).to receive(:send_file).with(file, caption: '', filename: nil)
+        event.attach_file(file, filename: filename)
         handler.after_call(event)
       end
     end

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -100,6 +100,39 @@ describe Discordrb::Events do
     end
   end
 
+  describe Discordrb::Events::MessageEvent do
+    let(:bot) { double }
+    let(:message) { double('message', channel: nil) }
+
+    subject :event do
+      described_class.new(message, bot)
+    end
+
+    describe '#attach_file' do
+      it 'defines an original_filename singleton when filename is passed' do
+        file = double(:file)
+        filename = double(:filename)
+
+        allow(file).to receive(:is_a?).with(File).and_return(true)
+        allow(file).to receive(:respond_to?).with(:read).and_return(true)
+
+        event.attach_file(file, filename: filename)
+
+        expect(file.original_filename).to eq filename
+      end
+
+      it 'does not define original_filename when filename is nil' do
+        file = double(:file)
+
+        allow(file).to receive(:is_a?).with(File).and_return(true)
+        allow(file).to receive(:respond_to?).with(:read).and_return(true)
+
+        expect(file).not_to receive(:define_singleton_method)
+        event.attach_file(file)
+      end
+    end
+  end
+
   describe Discordrb::Events::EventHandler do
     describe 'matches?' do
       it 'should raise an error' do


### PR DESCRIPTION
# Summary

Add the ability to provide a filename that will override the original name of the file when it is sent.

```ruby
event.send_file(File.open('rubytaco.png', 'r'), filename: 'the_ruby_taco.png')
```

---

## Added

Specs for `Bot#send_file`
Specs for `MessageEvent#attach_file`

## Changed

Added `filename` kwarg to the following:

- `Bot#send_file`
- `Channel#send_file`
- `User#send_file`
- `MessageEvent#send_file`
- `MessageEvent#attach_file`
