### PR TITLE
Add `spoiler` kwarg to methods that send_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `compress_mode` in `Bot.new` now defaults to `:large` instead of `:stream` ([#601](https://github.com/meew0/discordrb/pull/601))
 - `send_file` methods now accept `filename` to rename a file when uploading to Discord ([#605](https://github.com/meew0/discordrb/pull/605), thanks @swarley)
 - Emoji related `API` methods now accept arguments to change an emoji's role whitelist ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
+- `send_file` API now accepts a `spoiler` kwarg to send the file as a spoiler ([#606](https://github.com/meew0/discordrb/pull/606), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -397,11 +397,18 @@ module Discordrb
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
     # @param filename [String] Overrides the filename of the uploaded file
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
     # @example Send a file from disk
     #   bot.send_file(83281822225530880, File.open('rubytaco.png', 'r'))
-    def send_file(channel, file, caption: nil, tts: false, filename: nil)
-      # https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/payload.rb#L160
-      file.define_singleton_method(:original_filename) { filename } if file.respond_to?(:read) && filename
+    def send_file(channel, file, caption: nil, tts: false, filename: nil, spoiler: nil)
+      if file.respond_to?(:read)
+        if spoiler
+          filename ||= File.basename(file.path)
+          filename = 'SPOILER_' + filename unless filename.start_with? 'SPOILER_'
+        end
+        # https://github.com/rest-client/rest-client/blob/v2.0.2/lib/restclient/payload.rb#L160
+        file.define_singleton_method(:original_filename) { filename } if filename
+      end
 
       channel = channel.resolve_id
       response = API::Channel.upload_file(token, channel, file, caption: caption, tts: tts)

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -375,10 +375,11 @@ module Discordrb
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
     # @param filename [String] Overrides the filename of the uploaded file
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
     # @example Send a file from disk
     #   channel.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption: nil, tts: false, filename: nil)
-      @bot.send_file(@id, file, caption: caption, tts: tts, filename: filename)
+    def send_file(file, caption: nil, tts: false, filename: nil, spoiler: nil)
+      @bot.send_file(@id, file, caption: caption, tts: tts, filename: filename, spoiler: spoiler)
     end
 
     # Deletes a message on this channel. Mostly useful in case a message needs to be deleted when only the ID is known

--- a/lib/discordrb/data/user.rb
+++ b/lib/discordrb/data/user.rb
@@ -101,11 +101,12 @@ module Discordrb
     # @param file [File] The file to send to the user
     # @param caption [String] The caption of the file being sent
     # @param filename [String] Overrides the filename of the uploaded file
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
     # @return [Message] the message sent to this user.
     # @example Send a file from disk
     #   user.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption = nil, filename: nil)
-      pm.send_file(file, caption: caption, filename: filename)
+    def send_file(file, caption = nil, filename: nil, spoiler: nil)
+      pm.send_file(file, caption: caption, filename: filename, spoiler: spoiler)
     end
 
     # Set the user's name

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -88,6 +88,9 @@ module Discordrb::Events
     # @return [String] the filename set in {#attach_file} that will override the original filename when sent.
     attr_reader :filename
 
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler. Set by {#attach_file}
+    attr_reader :spoiler
+
     # @!attribute [r] author
     #   @return [Member, User] who sent this message.
     #   @see Message#author
@@ -114,6 +117,7 @@ module Discordrb::Events
       @saved_message = ''
       @file = nil
       @filename = nil
+      @spoiler = nil
     end
 
     # Sends file with a caption to the channel this message was sent in, right now.
@@ -122,22 +126,25 @@ module Discordrb::Events
     # @param file [File] The file to send to the channel
     # @param caption [String] The caption attached to the file
     # @param filename [String] Overrides the filename of the uploaded file
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
     # @return [Discordrb::Message] the message that was sent
     # @example Send a file from disk
     #   event.send_file(File.open('rubytaco.png', 'r'))
-    def send_file(file, caption: nil, filename: nil)
-      @message.channel.send_file(file, caption: caption, filename: filename)
+    def send_file(file, caption: nil, filename: nil, spoiler: nil)
+      @message.channel.send_file(file, caption: caption, filename: filename, spoiler: spoiler)
     end
 
     # Attaches a file to the message event and converts the message into
     # a caption.
     # @param file [File] The file to be attached
     # @param filename [String] Overrides the filename of the uploaded file
-    def attach_file(file, filename: nil)
+    # @param spoiler [true, false] Whether or not this file should appear as a spoiler.
+    def attach_file(file, filename: nil, spoiler: nil)
       raise ArgumentError, 'Argument is not a file!' unless file.is_a?(File)
 
       @file = file
       @filename = filename
+      @spoiler = spoiler
       nil
     end
 
@@ -145,6 +152,7 @@ module Discordrb::Events
     def detach_file
       @file = nil
       @filename = nil
+      @spoiler = nil
     end
 
     # @return [true, false] whether or not this message was sent by the bot itself
@@ -230,7 +238,7 @@ module Discordrb::Events
       if event.file.nil?
         event.send_message(event.saved_message) unless event.saved_message.empty?
       else
-        event.send_file(event.file, caption: event.saved_message, filename: event.filename)
+        event.send_file(event.file, caption: event.saved_message, filename: event.filename, spoiler: event.spoiler)
       end
     end
   end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -89,7 +89,7 @@ module Discordrb::Events
     attr_reader :filename
 
     # @return [true, false] Whether or not this file should appear as a spoiler. Set by {#attach_file}
-    attr_reader :spoiler
+    attr_reader :file_spoiler
 
     # @!attribute [r] author
     #   @return [Member, User] who sent this message.
@@ -117,7 +117,7 @@ module Discordrb::Events
       @saved_message = ''
       @file = nil
       @filename = nil
-      @spoiler = nil
+      @file_spoiler = nil
     end
 
     # Sends file with a caption to the channel this message was sent in, right now.
@@ -144,7 +144,7 @@ module Discordrb::Events
 
       @file = file
       @filename = filename
-      @spoiler = spoiler
+      @file_spoiler = spoiler
       nil
     end
 
@@ -152,7 +152,7 @@ module Discordrb::Events
     def detach_file
       @file = nil
       @filename = nil
-      @spoiler = nil
+      @file_spoiler = nil
     end
 
     # @return [true, false] whether or not this message was sent by the bot itself
@@ -238,7 +238,7 @@ module Discordrb::Events
       if event.file.nil?
         event.send_message(event.saved_message) unless event.saved_message.empty?
       else
-        event.send_file(event.file, caption: event.saved_message, filename: event.filename, spoiler: event.spoiler)
+        event.send_file(event.file, caption: event.saved_message, filename: event.filename, spoiler: event.file_spoiler)
       end
     end
   end

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -88,7 +88,7 @@ module Discordrb::Events
     # @return [String] the filename set in {#attach_file} that will override the original filename when sent.
     attr_reader :filename
 
-    # @param spoiler [true, false] Whether or not this file should appear as a spoiler. Set by {#attach_file}
+    # @return [true, false] Whether or not this file should appear as a spoiler. Set by {#attach_file}
     attr_reader :spoiler
 
     # @!attribute [r] author

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -167,5 +167,37 @@ describe Discordrb::Bot do
       bot.send_file(channel, file)
       expect(file.original_filename).to eq original_filename
     end
+
+    it 'prepends "SPOILER_" when spoiler is truthy and the filename does not start with "SPOILER_"' do
+      file = double(:file, read: true)
+
+      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
+      allow(Discordrb::Message).to receive(:new)
+
+      bot.send_file(channel, file, filename: 'file.txt', spoiler: true)
+      expect(file.original_filename).to eq 'SPOILER_file.txt'
+    end
+
+    it 'does not prepend "SPOILER_" when spoiler is truthy if filename.start_with? "SPOILER_"' do
+      file = double(:file, read: true)
+      original_filename = double(:original_filename)
+
+      allow(original_filename).to receive(:start_with?).with('SPOILER_').and_return(true)
+      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
+      allow(Discordrb::Message).to receive(:new)
+
+      bot.send_file(channel, file, filename: original_filename, spoiler: true)
+      expect(file.original_filename).to eq original_filename
+    end
+
+    it 'uses the original filename when spoiler is truthy and filename is nil' do
+      file = double(:file, read: true, path: 'file.txt')
+
+      allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
+      allow(Discordrb::Message).to receive(:new)
+
+      bot.send_file(channel, file, spoiler: true)
+      expect(file.original_filename).to eq 'SPOILER_file.txt'
+    end
   end
 end

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -178,13 +178,13 @@ describe Discordrb::Bot do
       expect(file.original_filename).to eq 'SPOILER_file.txt'
     end
 
-    it 'does not prepend "SPOILER_" when spoiler is truthy if filename.start_with? "SPOILER_"' do
-      file = double(:file, read: true)
+    it 'does not prepend "SPOILER_" if the filename starts with "SPOILER_"' do
+      file = double(:file, read: true, path: 'SPOILER_file.txt')
 
       allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
 
-      bot.send_file(channel, file, filename: 'SPOILER_file.txt', spoiler: true)
+      bot.send_file(channel, file, spoiler: true)
       expect(file.original_filename).to eq 'SPOILER_file.txt'
     end
 

--- a/spec/bot_spec.rb
+++ b/spec/bot_spec.rb
@@ -180,14 +180,12 @@ describe Discordrb::Bot do
 
     it 'does not prepend "SPOILER_" when spoiler is truthy if filename.start_with? "SPOILER_"' do
       file = double(:file, read: true)
-      original_filename = double(:original_filename)
 
-      allow(original_filename).to receive(:start_with?).with('SPOILER_').and_return(true)
       allow(Discordrb::API::Channel).to receive(:upload_file).and_return('{}')
       allow(Discordrb::Message).to receive(:new)
 
-      bot.send_file(channel, file, filename: original_filename, spoiler: true)
-      expect(file.original_filename).to eq original_filename
+      bot.send_file(channel, file, filename: 'SPOILER_file.txt', spoiler: true)
+      expect(file.original_filename).to eq 'SPOILER_file.txt'
     end
 
     it 'uses the original filename when spoiler is truthy and filename is nil' do

--- a/spec/event_spec.rb
+++ b/spec/event_spec.rb
@@ -114,13 +114,14 @@ describe Discordrb::Events do
         Discordrb::Events::MessageEventHandler.new(double, double('proc'))
       end
 
-      it 'calls send_file with attached file and filename' do
+      it 'calls send_file with attached file, filename, and spoiler' do
         file = double(:file)
         filename = double(:filename)
+        spoiler = double(:spoiler)
         allow(file).to receive(:is_a?).with(File).and_return(true)
 
-        expect(event).to receive(:send_file).with(file, caption: '', filename: filename)
-        event.attach_file(file, filename: filename)
+        expect(event).to receive(:send_file).with(file, caption: '', filename: filename, spoiler: spoiler)
+        event.attach_file(file, filename: filename, spoiler: spoiler)
         handler.after_call(event)
       end
     end


### PR DESCRIPTION
# Summary

Add a `spoiler` kwarg to methods that send files by overriding the original filename.

---

## Changed
- `Bot#send_file`
- `Channel#send_file`
- `User#send_file`
- `MessageEvent#send_file`
- `MessageEvent#attach_file`

