### PR TITLE
Sort roles by position in permissions calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emoji related `API` methods now accept arguments to change an emoji's role whitelist ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
 - `send_file` API now accepts a `spoiler` kwarg to send the file as a spoiler ([#606](https://github.com/meew0/discordrb/pull/606), thanks @swarley)
 
+### Fixed
+
+- Permission calculation when the internal sorting of roles is unreliable ([#609](https://github.com/meew0/discordrb/pull/609))
+
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0
 

--- a/lib/discordrb/permissions.rb
+++ b/lib/discordrb/permissions.rb
@@ -184,7 +184,7 @@ module Discordrb
       # For each role, check if
       #   (1) the channel explicitly allows or permits an action for the role and
       #   (2) if the user is allowed to do the action if the channel doesn't specify
-      roles_to_check.reduce(false) do |can_act, role|
+      roles_to_check.sort_by(&:position).reduce(false) do |can_act, role|
         # Get the override defined for the role on the channel
         channel_allow = permission_overwrite(action, channel, role.id)
         can_act = if channel_allow


### PR DESCRIPTION
The crux of this bug is based on the fact that the internal order of roles is undefined: they are in whatever order Discord sends them to us. This causes our reduce to be unstable based on this position, because of the following, where:

- each element is a role
- `true` represents permissions field being checked
- `pN` is the roles position

```
[false, true, false].reduce { |a, e| e } # => false
 p1     p3^^  p2

[false, false, true].reduce { |a, e| e } # => true
 p1     p2     p3^^
```

Sorting during our reduction ensures a set permission by a higher role
is not masked by a lower one.

Fixes #607 