### PR TITLE
Raise DisconnectEvent in handle_close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Permission calculation when the internal sorting of roles is unreliable ([#609](https://github.com/meew0/discordrb/pull/609))
+- `DisconnectEvent` is now raised when a gateway close frame is handled ([#611](https://github.com/meew0/discordrb/pull/611), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -772,6 +772,8 @@ module Discordrb
     end
 
     def handle_close(e)
+      @bot.send(:raise_event, Events::DisconnectEvent.new(@bot))
+
       if e.respond_to? :code
         # It is a proper close frame we're dealing with, print reason and message to console
         LOGGER.error('Websocket close frame received!')

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -772,7 +772,7 @@ module Discordrb
     end
 
     def handle_close(e)
-      @bot.send(:raise_event, Events::DisconnectEvent.new(@bot))
+      @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))
 
       if e.respond_to? :code
         # It is a proper close frame we're dealing with, print reason and message to console


### PR DESCRIPTION
Fixes #480

## Changed

`Gateway#handle_close` - now raises DisconnectEvent on parent bot instance.

