### PR TITLE
Adding MessageUpdateEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Attachment#spoiler?`, to check if an attachment is a spoiler or not ([#603](https://github.com/meew0/discordrb/pull/603), thanks @swarley)
 - Methods on `Server` to manage the server's emoji ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
 - `Paginator` utility class for wrapping paginated endpoints ([#579](https://github.com/meew0/discordrb/pull/579))
+- `EventContainer#message_update`, which is fired whenever a message is updated, either by Discord or the user ([#612](https://www.youtube.com/watch?v=fzpCAT4jiRE), thanks @swarley)
 
 ### Changed
 

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -1087,6 +1087,10 @@ module Discordrb
         update_message(data)
 
         message = Message.new(data, self)
+
+        event = MessageUpdateEvent.new(message, self)
+        raise_event(event)
+
         return if message.from_bot? && !should_parse_self
 
         unless message.author

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -109,6 +109,18 @@ module Discordrb
       register_event(MessageDeleteEvent, attributes, block)
     end
 
+    # This **event** is raised whenever a MESSAGE_UPDATE. This event catches some message updates that may
+    # not raise a MessageEditEvent. See [#507](https://github.com/meew0/discordrb/issues/507) for details.
+    # @param attributes [Hash] The event's attributes.
+    # @option attributes [#resolve_id] :id Matches the ID of the message that was updated.
+    # @option attributes [String, Integer, Channel] :in Matches the channel the message was updated in.
+    # @yield The block is executed when the event is raised.
+    # @yieldparam event [MessageUpdateEvent] The event that was raised.
+    # @return [MessageUpdateEventHandler] the event handler that was registered.
+    def message_update(attributes = {}, &block)
+      register_event(MessageUpdateEvent, attributes, block)
+    end
+
     # This **event** is raised when somebody reacts to a message.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [Integer, String] :emoji Matches the ID of the emoji that was reacted with, or its name.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -109,8 +109,10 @@ module Discordrb
       register_event(MessageDeleteEvent, attributes, block)
     end
 
-    # This **event** is raised whenever a MESSAGE_UPDATE. This event catches some message updates that may
-    # not raise a MessageEditEvent. See [#507](https://github.com/meew0/discordrb/issues/507) for details.
+    # This **event** is raised whenever a message is updated. Message updates can be triggered from
+    # a user editing their own message, or from Discord automatically attaching embeds to the
+    # user's message for URLs contained in the message's content. If you only want to listen
+    # for users editing their own messages, use the {message_edit} handler instead.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [#resolve_id] :id Matches the ID of the message that was updated.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was updated in.

--- a/lib/discordrb/events/message.rb
+++ b/lib/discordrb/events/message.rb
@@ -308,4 +308,11 @@ module Discordrb::Events
 
   # Event handler for {MessageDeleteEvent}
   class MessageDeleteEventHandler < MessageIDEventHandler; end
+
+  # Raised whenever a MESSAGE_UPDATE is recieved
+  # @see Discordrb::EventContainer#message_update
+  class MessageUpdateEvent < MessageEvent; end
+
+  # Event handler for {MessageUpdateEvent}
+  class MessageUpdateEventHandler < MessageEventHandler; end
 end


### PR DESCRIPTION
# Summary

Add a handler that fires on every `MESSAGE_UPDATE`.
Closes #507

## Added

`Events::MessageUpdateEvent`
`Events::MessageUpdateEventHandler`
`EventContainer#message_update`

## Changed

`Bot#handle_dispatch`

