### PR TITLE
Add `Message#server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Methods on `Server` to manage the server's emoji ([#595](https://github.com/meew0/discordrb/pull/595), thanks @swarley)
 - `Paginator` utility class for wrapping paginated endpoints ([#579](https://github.com/meew0/discordrb/pull/579))
 - `EventContainer#message_update`, which is fired whenever a message is updated, either by Discord or the user ([#612](https://www.youtube.com/watch?v=fzpCAT4jiRE), thanks @swarley)
+- `Message#server` ([#614](https://github.com/meew0/discordrb/pull/614), thanks @swarley)
 
 ### Changed
 

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -61,6 +61,9 @@ module Discordrb
     attr_reader :pinned
     alias_method :pinned?, :pinned
 
+    # @return [Server, nil] the server in which this message was sent.
+    attr_reader :server
+
     # @return [Integer, nil] the webhook ID that sent this message, or `nil` if it wasn't sent through a webhook.
     attr_reader :webhook_id
 
@@ -76,6 +79,8 @@ module Discordrb
       @tts = data['tts']
       @nonce = data['nonce']
       @mention_everyone = data['mention_everyone']
+
+      @server = bot.servers[data['guild_id'].to_i] if data['guild_id']
 
       @author = if data['author']
                   if data['author']['discriminator'] == ZERO_DISCRIM

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -80,7 +80,7 @@ module Discordrb
       @nonce = data['nonce']
       @mention_everyone = data['mention_everyone']
 
-      @server = bot.servers[data['guild_id'].to_i] if data['guild_id']
+      @server = bot.server(data['guild_id'].to_i) if data['guild_id']
 
       @author = if data['author']
                   if data['author']['discriminator'] == ZERO_DISCRIM


### PR DESCRIPTION
# Summary

Add a `server` reader to `Discordrb::Message`. This is primarily intended for convenience in a prefix proc.


## Added

`Discordrb::Message#server` - `Server` or `nil`

## Changed

`Discordrb::Message.initialize` - Assigns `server` instance var from `data['guild_id']`
