### PR TITLE
Remove #resolve_id duck typing

### DIFF
--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -339,7 +339,7 @@ module Discordrb
 
     # Disconnects the client from a specific voice connection given the server ID. Usually it's more convenient to use
     # {Discordrb::Voice::VoiceBot#destroy} rather than this.
-    # @param server [Server, String, Integer] The server, or server id, the voice connection is on.
+    # @param server [Server, String, Integer] The server, or server ID, the voice connection is on.
     # @param destroy_vws [true, false] Whether or not the VWS should also be destroyed. If you're calling this method
     #   directly, you should leave it as true.
     def voice_destroy(server, destroy_vws = true)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -162,7 +162,7 @@ module Discordrb
 
     # @overload emoji(id)
     #   Return an emoji by its ID
-    #   @param id [Integer, #resolve_id] The emoji's ID.
+    #   @param id [String, Integer] The emoji's ID.
     #   @return [Emoji, nil] the emoji object. `nil` if the emoji was not found.
     # @overload emoji
     #   The list of emoji the bot can use.
@@ -310,7 +310,7 @@ module Discordrb
     # data can then be sent. After connecting, the bot can also be accessed using {#voice}. If the bot is already
     # connected to voice, the existing connection will be terminated - you don't have to call
     # {Discordrb::Voice::VoiceBot#destroy} before calling this method.
-    # @param chan [Channel, Integer, #resolve_id] The voice channel to connect to.
+    # @param chan [Channel, String, Integer] The voice channel, or its ID, to connect to.
     # @param encrypted [true, false] Whether voice communication should be encrypted using RbNaCl's SecretBox
     #   (uses an XSalsa20 stream cipher for encryption and Poly1305 for authentication)
     # @return [Voice::VoiceBot] the initialized bot over which audio data can then be sent.
@@ -339,7 +339,7 @@ module Discordrb
 
     # Disconnects the client from a specific voice connection given the server ID. Usually it's more convenient to use
     # {Discordrb::Voice::VoiceBot#destroy} rather than this.
-    # @param server [Server, Integer, #resolve_id] The server the voice connection is on.
+    # @param server [Server, String, Integer] The server, or server id, the voice connection is on.
     # @param destroy_vws [true, false] Whether or not the VWS should also be destroyed. If you're calling this method
     #   directly, you should leave it as true.
     def voice_destroy(server, destroy_vws = true)
@@ -358,7 +358,7 @@ module Discordrb
     end
 
     # Sends a text message to a channel given its ID and the message's content.
-    # @param channel [Channel, Integer, #resolve_id] The channel to send something to.
+    # @param channel [Channel, String, Integer] The channel, or its ID, to send something to.
     # @param content [String] The text that should be sent as a message. It is limited to 2000 characters (Discord imposed).
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
     # @param embed [Hash, Discordrb::Webhooks::Embed, nil] The rich embed to append to this message.
@@ -373,7 +373,7 @@ module Discordrb
 
     # Sends a text message to a channel given its ID and the message's content,
     # then deletes it after the specified timeout in seconds.
-    # @param channel [Channel, Integer, #resolve_id] The channel to send something to.
+    # @param channel [Channel, String, Integer] The channel, or its ID, to send something to.
     # @param content [String] The text that should be sent as a message. It is limited to 2000 characters (Discord imposed).
     # @param timeout [Float] The amount of time in seconds after which the message sent will be deleted.
     # @param tts [true, false] Whether or not this message should be sent using Discord text-to-speech.
@@ -392,7 +392,7 @@ module Discordrb
 
     # Sends a file to a channel. If it is an image, it will automatically be embedded.
     # @note This executes in a blocking way, so if you're sending long files, be wary of delays.
-    # @param channel [Channel, Integer, #resolve_id] The channel to send something to.
+    # @param channel [Channel, String, Integer] The channel, or its ID, to send something to.
     # @param file [File] The file that should be sent.
     # @param caption [string] The caption for the file.
     # @param tts [true, false] Whether or not this file's caption should be sent using Discord text-to-speech.
@@ -652,19 +652,19 @@ module Discordrb
     # Add a user to the list of ignored users. Those users will be ignored in message events at event processing level.
     # @note Ignoring a user only prevents any message events (including mentions, commands etc.) from them! Typing and
     #   presence and any other events will still be received.
-    # @param user [User, Integer, #resolve_id] The user, or its ID, to be ignored.
+    # @param user [User, String, Integer] The user, or its ID, to be ignored.
     def ignore_user(user)
       @ignored_ids << user.resolve_id
     end
 
     # Remove a user from the ignore list.
-    # @param user [User, Integer, #resolve_id] The user, or its ID, to be unignored.
+    # @param user [User, String, Integer] The user, or its ID, to be unignored.
     def unignore_user(user)
       @ignored_ids.delete(user.resolve_id)
     end
 
     # Checks whether a user is being ignored.
-    # @param user [User, Integer, #resolve_id] The user, or its ID, to check.
+    # @param user [User, String, Integer] The user, or its ID, to check.
     # @return [true, false] whether or not the user is ignored.
     def ignored?(user)
       @ignored_ids.include?(user.resolve_id)

--- a/lib/discordrb/bot.rb
+++ b/lib/discordrb/bot.rb
@@ -276,7 +276,7 @@ module Discordrb
 
     # Creates an OAuth invite URL that can be used to invite this bot to a particular server.
     # @param server [Server, nil] The server the bot should be invited to, or nil if a general invite should be created.
-    # @param permission_bits [Integer, String] Permission bits that should be appended to invite url.
+    # @param permission_bits [String, Integer] Permission bits that should be appended to invite url.
     # @return [String] the OAuth invite URL.
     def invite_url(server: nil, permission_bits: nil)
       @client_id ||= bot_application.id

--- a/lib/discordrb/colour_rgb.rb
+++ b/lib/discordrb/colour_rgb.rb
@@ -18,7 +18,7 @@ module Discordrb
     alias_method :to_i, :combined
 
     # Make a new colour from the combined value.
-    # @param combined [Integer, String] The colour's RGB values combined into one integer or a hexadecimal string
+    # @param combined [String, Integer] The colour's RGB values combined into one integer or a hexadecimal string
     # @example Initialize a with a base 10 integer
     #   ColourRGB.new(7506394) #=> ColourRGB
     #   ColourRGB.new(0x7289da) #=> ColourRGB

--- a/lib/discordrb/commands/container.rb
+++ b/lib/discordrb/commands/container.rb
@@ -22,9 +22,9 @@ module Discordrb::Commands
     #   the message by setting this option to false.
     # @option attributes [Array<Symbol>] :required_permissions Discord action permissions (e.g. `:kick_members`) that
     #   should be required to use this command. See {Discordrb::Permissions::FLAGS} for a list.
-    # @option attributes [Array<Role>, Array<#resolve_id>] :required_roles Roles that user must have to use this command
+    # @option attributes [Array<Role>, Array<String, Integer>] :required_roles Roles, or their IDs, that user must have to use this command
     #   (user must have all of them).
-    # @option attributes [Array<Role>, Array<#resolve_id>] :allowed_roles Roles that user should have to use this command
+    # @option attributes [Array<Role>, Array<String, Integer>] :allowed_roles Roles, or their IDs, that user should have to use this command
     #   (user should have at least one of them).
     # @option attributes [Array<String, Integer, Channel>] :channels The channels that this command can be used on. An
     #   empty array indicates it can be used on any channel. Supersedes the command bot attribute.

--- a/lib/discordrb/commands/rate_limiter.rb
+++ b/lib/discordrb/commands/rate_limiter.rb
@@ -35,7 +35,7 @@ module Discordrb::Commands
     end
 
     # Performs a rate limiting request
-    # @param thing [#resolve_id, Integer, Symbol] The particular thing that should be rate-limited (usually a user/channel, but you can also choose arbitrary integers or symbols)
+    # @param thing [String, Integer, Symbol] The particular thing that should be rate-limited (usually a user/channel, but you can also choose arbitrary integers or symbols)
     # @param rate_limit_time [Time] The time to base the rate limiting on, only useful for testing.
     # @param increment [Integer] How much to increment the rate-limit counter. Default is 1.
     # @return [Integer, false] the waiting time until the next request, in seconds, or false if the request succeeded
@@ -105,7 +105,7 @@ module Discordrb::Commands
 
     # Performs a rate limit request.
     # @param key [Symbol] Which bucket to perform the request for.
-    # @param thing [#resolve_id, Integer, Symbol] What should be rate-limited.
+    # @param thing [String, Integer, Symbol] What should be rate-limited.
     # @param increment (see Bucket#rate_limited?)
     # @see Bucket#rate_limited?
     # @return [Integer, false] How much time to wait or false if the request succeeded.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -125,7 +125,7 @@ module Discordrb
 
     # This **event** is raised when somebody reacts to a message.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [Integer, String] :emoji Matches the ID of the emoji that was reacted with, or its name.
+    # @option attributes [String, Integer] :emoji Matches the ID of the emoji that was reacted with, or its name.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionAddEvent] The event that was raised.
     # @return [ReactionAddEventHandler] The event handler that was registered.
@@ -135,7 +135,7 @@ module Discordrb
 
     # This **event** is raised when somebody removes a reaction from a message.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [Integer, String] :emoji Matches the ID of the emoji that was removed from the reactions, or
+    # @option attributes [String, Integer] :emoji Matches the ID of the emoji that was removed from the reactions, or
     #   its name.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ReactionRemoveEvent] The event that was raised.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -230,8 +230,8 @@ module Discordrb
     # This **event** is raised when a recipient is added to a group channel.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String] :name Matches the name of the group channel that the recipient is added to.
-    # @option attributes [String, Integer] :owner_id Matches the id of the group channel's owner.
-    # @option attributes [String, Integer] :id Matches the id of the recipient added to the group channel.
+    # @option attributes [String, Integer] :owner_id Matches the ID of the group channel's owner.
+    # @option attributes [String, Integer] :id Matches the ID of the recipient added to the group channel.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ChannelRecipientAddEvent] The event that was raised.
     # @return [ChannelRecipientAddHandler] the event handler that was registered.
@@ -242,8 +242,8 @@ module Discordrb
     # This **event** is raised when a recipient is removed from a group channel.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String] :name Matches the name of the group channel that the recipient is added to.
-    # @option attributes [String, Integer] :owner_id Matches the id of the group channel's owner.
-    # @option attributes [String, Integer] :id Matches the id of the recipient removed from the group channel.
+    # @option attributes [String, Integer] :owner_id Matches the ID of the group channel's owner.
+    # @option attributes [String, Integer] :id Matches the ID of the recipient removed from the group channel.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ChannelRecipientRemoveEvent] The event that was raised.
     # @return [ChannelRecipientRemoveHandler] the event handler that was registered.
@@ -366,7 +366,7 @@ module Discordrb
     # This **event** is raised when an emoji is created.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer, Server] :server Matches the server.
-    # @option attributes [String, Integer] :id Matches the id of the emoji.
+    # @option attributes [String, Integer] :id Matches the ID of the emoji.
     # @option attributes [String] :name Matches the name of the emoji.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ServerEmojiCreateEvent] The event that was raised.
@@ -378,7 +378,7 @@ module Discordrb
     # This **event** is raised when an emoji is deleted.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer, Server] :server Matches the server.
-    # @option attributes [String, Integer] :id Matches the id of the emoji.
+    # @option attributes [String, Integer] :id Matches the ID of the emoji.
     # @option attributes [String] :name Matches the name of the emoji.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ServerEmojiDeleteEvent] The event that was raised.
@@ -390,7 +390,7 @@ module Discordrb
     # This **event** is raised when an emoji is updated.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String, Integer, Server] :server Matches the server.
-    # @option attributes [String, Integer] :id Matches the id of the emoji.
+    # @option attributes [String, Integer] :id Matches the ID of the emoji.
     # @option attributes [String] :name Matches the name of the emoji.
     # @option attributes [String] :old_name Matches the name of the emoji before the update.
     # @yield The block is executed when the event is raised.
@@ -412,7 +412,7 @@ module Discordrb
 
     # This **event** is raised when a role is deleted.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [String, Integer] :id Matches the role id.
+    # @option attributes [String, Integer] :id Matches the role ID.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ServerRoleDeleteEvent] The event that was raised.
     # @return [ServerRoleDeleteEventHandler] the event handler that was registered.
@@ -432,9 +432,9 @@ module Discordrb
 
     # This **event** is raised when a webhook is updated.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [String, Integer, Server] :server Matches the server by name, id or instance.
-    # @option attributes [String, Integer, Channel] :channel Matches the channel by name, id or instance.
-    # @option attribute [String, Integer, Webhook] :webhook Matches the webhook by name, id or instance.
+    # @option attributes [String, Integer, Server] :server Matches the server by name, ID or instance.
+    # @option attributes [String, Integer, Channel] :channel Matches the channel by name, ID or instance.
+    # @option attribute [String, Integer, Webhook] :webhook Matches the webhook by name, ID or instance.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [WebhookUpdateEvent] The event that was raised.
     # @return [WebhookUpdateEventHandler] the event handler that was registered.

--- a/lib/discordrb/container.rb
+++ b/lib/discordrb/container.rb
@@ -89,7 +89,7 @@ module Discordrb
 
     # This **event** is raised when a message is edited in a channel.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [#resolve_id] :id Matches the ID of the message that was edited.
+    # @option attributes [String, Integer] :id Matches the ID of the message that was edited.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was edited in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageEditEvent] The event that was raised.
@@ -100,7 +100,7 @@ module Discordrb
 
     # This **event** is raised when a message is deleted in a channel.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [#resolve_id] :id Matches the ID of the message that was deleted.
+    # @option attributes [String, Integer] :id Matches the ID of the message that was deleted.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was deleted in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageDeleteEvent] The event that was raised.
@@ -114,7 +114,7 @@ module Discordrb
     # user's message for URLs contained in the message's content. If you only want to listen
     # for users editing their own messages, use the {message_edit} handler instead.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [#resolve_id] :id Matches the ID of the message that was updated.
+    # @option attributes [String, Integer] :id Matches the ID of the message that was updated.
     # @option attributes [String, Integer, Channel] :in Matches the channel the message was updated in.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [MessageUpdateEvent] The event that was raised.
@@ -230,8 +230,8 @@ module Discordrb
     # This **event** is raised when a recipient is added to a group channel.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String] :name Matches the name of the group channel that the recipient is added to.
-    # @option attributes [#resolve_id] :owner_id Matches the id of the group channel's owner.
-    # @option attributes [#resolve_id] :id Matches the id of the recipient added to the group channel.
+    # @option attributes [String, Integer] :owner_id Matches the id of the group channel's owner.
+    # @option attributes [String, Integer] :id Matches the id of the recipient added to the group channel.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ChannelRecipientAddEvent] The event that was raised.
     # @return [ChannelRecipientAddHandler] the event handler that was registered.
@@ -242,8 +242,8 @@ module Discordrb
     # This **event** is raised when a recipient is removed from a group channel.
     # @param attributes [Hash] The event's attributes.
     # @option attributes [String] :name Matches the name of the group channel that the recipient is added to.
-    # @option attributes [#resolve_id] :owner_id Matches the id of the group channel's owner.
-    # @option attributes [#resolve_id] :id Matches the id of the recipient removed from the group channel.
+    # @option attributes [String, Integer] :owner_id Matches the id of the group channel's owner.
+    # @option attributes [String, Integer] :id Matches the id of the recipient removed from the group channel.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ChannelRecipientRemoveEvent] The event that was raised.
     # @return [ChannelRecipientRemoveHandler] the event handler that was registered.
@@ -412,7 +412,7 @@ module Discordrb
 
     # This **event** is raised when a role is deleted.
     # @param attributes [Hash] The event's attributes.
-    # @option attributes [#resolve_id] :id Matches the role id.
+    # @option attributes [String, Integer] :id Matches the role id.
     # @yield The block is executed when the event is raised.
     # @yieldparam event [ServerRoleDeleteEvent] The event that was raised.
     # @return [ServerRoleDeleteEventHandler] the event handler that was registered.

--- a/lib/discordrb/data/audit_logs.rb
+++ b/lib/discordrb/data/audit_logs.rb
@@ -250,14 +250,14 @@ module Discordrb
 
     # Gets a user in the audit logs data based on user ID
     # @note This only uses data given by the audit logs request
-    # @param id [#resolve_id] The user ID to look for
+    # @param id [String, Integer] The user ID to look for
     def user(id)
       @users[id.resolve_id]
     end
 
     # Gets a webhook in the audit logs data based on webhook ID
     # @note This only uses data given by the audit logs request
-    # @param id [#resolve_id] The webhook ID to look for
+    # @param id [String, Integer] The webhook ID to look for
     def webhook(id)
       @webhooks[id.resolve_id]
     end

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -26,7 +26,7 @@ module Discordrb
     # @return [Integer] the type of this channel (0: text, 1: private, 2: voice, 3: group)
     attr_reader :type
 
-    # @return [Integer, nil] the id of the owner of the group channel or nil if this is not a group channel.
+    # @return [Integer, nil] the ID of the owner of the group channel or nil if this is not a group channel.
     attr_reader :owner_id
 
     # @return [Array<Recipient>, nil] the array of recipients of the private messages, or nil if this is not a Private channel

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -138,7 +138,7 @@ module Discordrb
     alias_method :parent, :category
 
     # Sets this channels parent category
-    # @param channel [Channel, #resolve_id] the target category channel
+    # @param channel [Channel, String, Integer] the target category channel, or its ID
     # @raise [ArgumentError] if the target channel isn't a category
     def category=(channel)
       channel = @bot.channel(channel)
@@ -150,12 +150,12 @@ module Discordrb
     alias_method :parent=, :category=
 
     # Sorts this channel's position to follow another channel.
-    # @param other [Channel, #resolve_id, nil] The channel below which this channel should be sorted. If the given
+    # @param other [Channel, String, Integer, nil] The channel, or its ID, below which this channel should be sorted. If the given
     #   channel is a category, this channel will be sorted at the top of that category. If it is `nil`, the channel will
     #   be sorted at the top of the channel list.
     # @param lock_permissions [true, false] Whether the channel's permissions should be synced to the category's
     def sort_after(other = nil, lock_permissions = false)
-      raise TypeError, 'other must be one of Channel, NilClass, or #resolve_id' unless other.is_a?(Channel) || other.nil? || other.respond_to?(:resolve_id)
+      raise TypeError, 'other must be one of Channel, NilClass, String, or Integer' unless other.is_a?(Channel) || other.nil? || other.respond_to?(:resolve_id)
 
       other = @bot.channel(other.resolve_id) if other
 
@@ -383,7 +383,7 @@ module Discordrb
     end
 
     # Deletes a message on this channel. Mostly useful in case a message needs to be deleted when only the ID is known
-    # @param message [Message, String, Integer, #resolve_id] The message that should be deleted.
+    # @param message [Message, String, Integer, String, Integer] The message, or its ID, that should be deleted.
     def delete_message(message)
       API::Channel.delete_message(@bot.token, @id, message.resolve_id)
     end
@@ -465,7 +465,7 @@ module Discordrb
     end
 
     # Deletes a permission overwrite for this channel
-    # @param target [Member, User, Role, Profile, Recipient, #resolve_id] What permission overwrite to delete
+    # @param target [Member, User, Role, Profile, Recipient, String, Integer] What permission overwrite to delete
     #   @param reason [String] The reason the for the overwrite deletion.
     def delete_overwrite(target, reason = nil)
       raise 'Tried deleting a overwrite for an invalid target' unless target.is_a?(Member) || target.is_a?(User) || target.is_a?(Role) || target.is_a?(Profile) || target.is_a?(Recipient) || target.respond_to?(:resolve_id)
@@ -577,7 +577,7 @@ module Discordrb
     end
 
     # Deletes a collection of messages
-    # @param messages [Array<Message, Integer, #resolve_id>] the messages (or message IDs) to delete. Total must be an amount between 2 and 100 (Discord limitation)
+    # @param messages [Array<Message, String, Integer>] the messages (or message IDs) to delete. Total must be an amount between 2 and 100 (Discord limitation)
     # @param strict [true, false] Whether an error should be raised when a message is reached that is too old to be bulk
     #   deleted. If this is false only a warning message will be output to the console.
     # @raise [ArgumentError] if the amount of messages is not a value between 2 and 100
@@ -647,7 +647,7 @@ module Discordrb
     end
 
     # Adds a user to a group channel.
-    # @param user_ids [Array<#resolve_id>, #resolve_id] User ID or array of user IDs to add to the group channel.
+    # @param user_ids [Array<String, Integer>, String, Integer] User ID or array of user IDs to add to the group channel.
     # @return [Channel] the group channel.
     def add_group_users(user_ids)
       raise 'Attempted to add a user to a non-group channel!' unless group?
@@ -662,7 +662,7 @@ module Discordrb
     alias_method :add_group_user, :add_group_users
 
     # Removes a user from a group channel.
-    # @param user_ids [Array<#resolve_id>, #resolve_id] User ID or array of user IDs to remove from the group channel.
+    # @param user_ids [Array<String, Integer>, String, Integer] User ID or array of user IDs to remove from the group channel.
     # @return [Channel] the group channel.
     def remove_group_users(user_ids)
       raise 'Attempted to remove a user from a non-group channel!' unless group?

--- a/lib/discordrb/data/member.rb
+++ b/lib/discordrb/data/member.rb
@@ -76,7 +76,7 @@ module Discordrb
       @server.owner == self
     end
 
-    # @param role [Role, Integer, #resolve_id] the role to check or its ID.
+    # @param role [Role, String, Integer] the role to check or its ID.
     # @return [true, false] whether this member has the specified role.
     def role?(role)
       role = role.resolve_id
@@ -114,7 +114,7 @@ module Discordrb
     end
 
     # Adds one or more roles to this member.
-    # @param role [Role, Array<Role, #resolve_id>, #resolve_id] The role(s) to add.
+    # @param role [Role, Array<Role, String, Integer>, String, Integer] The role(s), or their ID(s), to add.
     # @param reason [String] The reason the user's roles are being changed.
     def add_role(role, reason = nil)
       role_ids = role_id_array(role)

--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -260,7 +260,7 @@ module Discordrb
     end
 
     # Deletes a reaction made by a user on this message.
-    # @param user [User, #resolve_id] the user who used this reaction
+    # @param user [User, String, Integer] the user or user ID who used this reaction
     # @param reaction [String, #to_reaction] the reaction to remove
     def delete_reaction(user, reaction)
       reaction = reaction.to_reaction if reaction.respond_to?(:to_reaction)

--- a/lib/discordrb/data/overwrite.rb
+++ b/lib/discordrb/data/overwrite.rb
@@ -4,7 +4,7 @@ module Discordrb
   # A permissions overwrite, when applied to channels describes additional
   # permissions a member needs to perform certain actions in context.
   class Overwrite
-    # @return [Integer] id of the thing associated with this overwrite type
+    # @return [Integer] ID of the thing associated with this overwrite type
     attr_accessor :id
 
     # @return [Symbol] either :role or :member

--- a/lib/discordrb/data/role.rb
+++ b/lib/discordrb/data/role.rb
@@ -146,7 +146,7 @@ module Discordrb
     end
 
     # Moves this role above another role in the list.
-    # @param other [Role, #resolve_id, nil] The role above which this role should be moved. If it is `nil`,
+    # @param other [Role, String, Integer, nil] The role, or its ID, above which this role should be moved. If it is `nil`,
     #   the role will be moved above the @everyone role.
     # @return [Integer] the new position of this role
     def sort_above(other = nil)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -110,7 +110,7 @@ module Discordrb
     end
 
     # Gets a role on this server based on its ID.
-    # @param id [Integer, String, #resolve_id] The role ID to look for.
+    # @param id [String, Integer] The role ID to look for.
     def role(id)
       id = id.resolve_id
       @roles.find { |e| e.id == id }
@@ -518,16 +518,16 @@ module Discordrb
     end
 
     # Delete a custom emoji on this server
-    # @param emoji [Emoji, Integer, String] The emoji or emoji ID to be deleted.
+    # @param emoji [Emoji, String, Integer] The emoji or emoji ID to be deleted.
     # @param reason [String] The reason the for the deletion of this emoji.
     def delete_emoji(emoji, reason: nil)
       API::Server.delete_emoji(@bot.token, @id, emoji.resolve_id, reason)
     end
 
     # Changes the name and/or role whitelist of an emoji on this server.
-    # @param emoji [Emoji, Integer, String] The emoji or emoji ID to edit.
+    # @param emoji [Emoji, String, Integer] The emoji or emoji ID to edit.
     # @param name [String] The new name for the emoji.
-    # @param roles [Array<Role, Integer, String>] A new array of roles, or role IDs, to whitelist.
+    # @param roles [Array<Role, String, Integer>] A new array of roles, or role IDs, to whitelist.
     # @param reason [String] The reason for the editing of this emoji.
     # @return [Emoji] The edited emoji.
     def edit_emoji(emoji, name: nil, roles: nil, reason: nil)

--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -154,9 +154,9 @@ module Discordrb
     end
 
     # @param action [Symbol] The action to only include.
-    # @param user [User, #resolve_id] The user to filter entries to.
+    # @param user [User, String, Integer] The user, or their ID, to filter entries to.
     # @param limit [Integer] The amount of entries to limit it to.
-    # @param before [Entry, #resolve_id] The entry to use to not include all entries after it.
+    # @param before [Entry, String, Integer] The entry, or its ID, to use to not include all entries after it.
     # @return [AuditLogs] The server's audit logs.
     def audit_logs(action: nil, user: nil, limit: 50, before: nil)
       raise 'Invalid audit log action!' if action && AuditLogs::ACTIONS.key(action).nil?
@@ -210,7 +210,7 @@ module Discordrb
     alias_method :set_widget_enabled, :set_embed_enabled
 
     # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer, #resolve_id] the channel to be referenced by the embed
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
     def embed_channel=(channel)
       modify_embed(embed?, channel)
     end
@@ -218,7 +218,7 @@ module Discordrb
     alias_method :widget_channel=, :embed_channel=
 
     # Changes the channel on the server's embed (widget)
-    # @param channel [Channel, String, Integer, #resolve_id] the channel to be referenced by the embed
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
     # @param reason [String, nil] the reason to be shown in the audit log for this action
     def set_embed_channel(channel, reason = nil)
       modify_embed(embed?, channel, reason)
@@ -228,7 +228,7 @@ module Discordrb
 
     # Changes the channel on the server's embed (widget), and sets whether it is enabled.
     # @param enabled [true, false] whether the embed (widget) is enabled
-    # @param channel [Channel, String, Integer, #resolve_id] the channel to be referenced by the embed
+    # @param channel [Channel, String, Integer] the channel, or its ID, to be referenced by the embed
     # @param reason [String, nil] the reason to be shown in the audit log for this action
     def modify_embed(enabled, channel, reason = nil)
       cache_embed_data if @embed_enabled.nil?
@@ -255,10 +255,10 @@ module Discordrb
     # with the `guilds.join` scope.
     # For more information about Discord's OAuth2 implementation, see: https://discordapp.com/developers/docs/topics/oauth2
     # @note Your bot must be present in this server, and have permission to create instant invites for this to work.
-    # @param user [Integer, User, #resolve_id] the user, or ID of the user to add to this server
+    # @param user [User, String, Integer] the user, or ID of the user to add to this server
     # @param access_token [String] the OAuth2 Bearer token that has been granted the `guilds.join` scope
     # @param nick [String] the nickname to give this member upon joining
-    # @param roles [Role, Array<Integer, Role, #resolve_id>] the role (or roles) to give this member upon joining
+    # @param roles [Role, Array<Role, String, Integer>] the role (or roles) to give this member upon joining
     # @param deaf [true, false] whether this member will be server deafened upon joining
     # @param mute [true, false] whether this member will be server muted upon joining
     # @return [Member] the created member
@@ -455,7 +455,7 @@ module Discordrb
     # @param bitrate [Integer] the bitrate of this channel, if it will be a voice channel
     # @param user_limit [Integer] the user limit of this channel, if it will be a voice channel
     # @param permission_overwrites [Array<Hash>, Array<Overwrite>] permission overwrites for this channel
-    # @param parent [Channel, #resolve_id] parent category for this channel to be created in.
+    # @param parent [Channel, String, Integer] parent category, or its ID, for this channel to be created in.
     # @param nsfw [true, false] whether this channel should be created as nsfw
     # @param rate_limit_per_user [Integer] how many seconds users need to wait in between messages.
     # @param reason [String] The reason the for the creation of this channel.
@@ -546,7 +546,7 @@ module Discordrb
     end
 
     # Bans a user from this server.
-    # @param user [User, #resolve_id] The user to ban.
+    # @param user [User, String, Integer] The user to ban.
     # @param message_days [Integer] How many days worth of messages sent by the user should be deleted.
     # @param reason [String] The reason the user is being banned.
     def ban(user, message_days = 0, reason: nil)
@@ -554,22 +554,22 @@ module Discordrb
     end
 
     # Unbans a previously banned user from this server.
-    # @param user [User, #resolve_id] The user to unban.
+    # @param user [User, String, Integer] The user to unban.
     # @param reason [String] The reason the user is being unbanned.
     def unban(user, reason = nil)
       API::Server.unban_user(@bot.token, @id, user.resolve_id, reason)
     end
 
     # Kicks a user from this server.
-    # @param user [User, #resolve_id] The user to kick.
+    # @param user [User, String, Integer] The user to kick.
     # @param reason [String] The reason the user is being kicked.
     def kick(user, reason = nil)
       API::Server.remove_member(@bot.token, @id, user.resolve_id, reason)
     end
 
     # Forcibly moves a user into a different voice channel. Only works if the bot has the permission needed.
-    # @param user [User, #resolve_id] The user to move.
-    # @param channel [Channel, #resolve_id] The voice channel to move into.
+    # @param user [User, String, Integer] The user to move.
+    # @param channel [Channel, String, Integer] The voice channel to move into.
     def move(user, channel)
       API::Server.update_member(@bot.token, @id, user.resolve_id, channel_id: channel.resolve_id)
     end
@@ -585,7 +585,7 @@ module Discordrb
     end
 
     # Transfers server ownership to another user.
-    # @param user [User, #resolve_id] The user who should become the new owner.
+    # @param user [User, String, Integer] The user who should become the new owner.
     def owner=(user)
       API::Server.transfer_ownership(@bot.token, @id, user.resolve_id)
     end
@@ -637,7 +637,7 @@ module Discordrb
     end
 
     # Sets the server's system channel.
-    # @param system_channel [Channel, String, Integer, #resolve_id, nil] The new system channel, or `nil` should it be disabled.
+    # @param system_channel [Channel, String, Integer, nil] The new system channel, or `nil` should it be disabled.
     def system_channel=(system_channel)
       update_server_data(system_channel_id: system_channel.resolve_id)
     end

--- a/lib/discordrb/data/webhook.rb
+++ b/lib/discordrb/data/webhook.rb
@@ -57,7 +57,7 @@ module Discordrb
     end
 
     # Sets the webhook's channel
-    # @param channel [Channel, String, Integer, #resolve_id] The channel the webhook should use.
+    # @param channel [Channel, String, Integer] The channel the webhook should use.
     def channel=(channel)
       update_webhook(channel_id: channel.resolve_id)
     end
@@ -71,7 +71,7 @@ module Discordrb
     # Updates the webhook if you need to edit more than 1 attribute.
     # @param data [Hash] the data to update.
     # @option data [String, #read, nil] :avatar The new avatar, in base64-encoded JPG format, or nil to delete the avatar.
-    # @option data [Channel, String, Integer, #resolve_id] :channel The channel the webhook should use.
+    # @option data [Channel, String, Integer] :channel The channel the webhook should use.
     # @option data [String] :name The webhook's new name.
     # @option data [String] :reason The reason for the webhook changes.
     def update(data)

--- a/lib/discordrb/webhooks/embeds.rb
+++ b/lib/discordrb/webhooks/embeds.rb
@@ -37,7 +37,7 @@ module Discordrb::Webhooks
     alias_method :color, :colour
 
     # Sets the colour of the bar to the side of the embed to something new.
-    # @param value [Integer, String, {Integer, Integer, Integer}, #to_i, nil] The colour in decimal, hexadecimal, R/G/B decimal, or nil to clear the embeds colour
+    # @param value [String, Integer, {Integer, Integer, Integer}, #to_i, nil] The colour in decimal, hexadecimal, R/G/B decimal, or nil to clear the embeds colour
     #   form.
     def colour=(value)
       if value.nil?


### PR DESCRIPTION
# Summary

Remove all instances of `#resolve_id` duck typing in docs. Clarify that an ID can be used in many places instead of the relevant object.

Many docs types are changed as well as inclusion of the mention of ID in the description string. Many of these could be potentially worded differently.

Closes #512 