### PR TITLE
Removing old logic regarding nsfw channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Permission calculation when the internal sorting of roles is unreliable ([#609](https://github.com/meew0/discordrb/pull/609))
 - `DisconnectEvent` is now raised when a gateway close frame is handled ([#611](https://github.com/meew0/discordrb/pull/611), thanks @swarley)
+- A cached `Channel` is no longer assumed to be NSFW if its name starts with `nsfw` ([#617](https://github.com/meew0/discordrb/pull/617), thanks @swarley)
 
 ## [3.3.0] - 2018-10-27
 [3.3.0]: https://github.com/meew0/discordrb/releases/tag/v3.3.0

--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -99,7 +99,7 @@ module Discordrb
         @server = server || bot.server(data['guild_id'].to_i)
       end
 
-      @nsfw = data['nsfw'] || false || @name.start_with?('nsfw')
+      @nsfw = data['nsfw'] || false
       @rate_limit_per_user = data['rate_limit_per_user'] || 0
 
       process_permission_overwrites(data['permission_overwrites'])


### PR DESCRIPTION
# Summary

Remove logic that checked for a 'nsfw' prefix in channel names to determine nsfw-ness.

---

## Changed

`Discordrb::Channel.initialize`

