### PR TITLE
Tighten RuboCop dependency again

### DIFF
--- a/discordrb.gemspec
+++ b/discordrb.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.4.0' # YARD markdown formatting
   spec.add_development_dependency 'rspec', '~> 3.8.0'
   spec.add_development_dependency 'rspec-prof', '~> 0.0.7'
-  spec.add_development_dependency 'rubocop', '~> 0.60'
+  spec.add_development_dependency 'rubocop', '~> 0.66.0'
   spec.add_development_dependency 'simplecov', '~> 0.16.0'
   spec.add_development_dependency 'yard', '~> 0.9.9'
 end


### PR DESCRIPTION


# Summary

Don't need to be breaking builds because RuboCop got an update; having to update the RuboCop dep more often is definitely better than annoying surprises.

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Fixed

- RuboCop is tightened down to a specific minor version again, to avoid breaking builds because of cop changes.