### PR TITLE
Add convenience methods for getting bot and non bot members

### DIFF
--- a/lib/discordrb/data/server.rb
+++ b/lib/discordrb/data/server.rb
@@ -142,6 +142,16 @@ module Discordrb
 
     alias_method :users, :members
 
+    # @return [Array<Member>] an array of all the bot members on this server.
+    def bot_members
+      members.select(&:bot_account?)
+    end
+
+    # @return [Array<Member>] an array of all the non bot members on this server.
+    def non_bot_members
+      members.reject(&:bot_account?)
+    end
+
     # @return [Member] the bot's own `Member` on this server
     def bot
       member(@bot.profile)


### PR DESCRIPTION
# Summary

Adds two methods to the server class for getting filtered versions of the members list, one with only bot users and one excluding bot users.

There are methods for filtering channels by type not not any for filtering members by type. 

<!---
  Describe the general goal of your pull request here:

  - Include details about any issues you encountered that inspired
  the pull request, such as bugs or missing features.

  - If adding or changing features, include a small example that showcases
  the new behavior.

  - Reference any related issues or pull requests.

  Stuck or need help? Join the Discord! https://discord.gg/cyK3Hjm
--->

---

<!---
  List each individual change you made to the library here in the appropriate
  section in short, bulleted sentences.

  This will aid in reviewing your pull request, and for adding it to the
  changelog later.

  You may remove sections that have no items if you want.
--->

## Added
* `Server#bot_members` - gets a list of members that are bot accounts
* `Server#non_bot_members` - get a list of members excluding bot accounts

## Changed

## Deprecated

## Removed

## Fixed
