### PR TITLE
Fix issue with implicit return on #split_send

### DIFF
--- a/lib/discordrb/data/channel.rb
+++ b/lib/discordrb/data/channel.rb
@@ -380,6 +380,7 @@ module Discordrb
     # Useful for sending long messages, but be wary of rate limits!
     def split_send(content)
       send_multiple(Discordrb.split_message(content))
+      nil
     end
 
     # Sends a file to this channel. If it is an image, it will be embedded.


### PR DESCRIPTION
# Summary

split_send was returning a large array that tripped a MessageTooLong exception due to commandbot implict return on commands. Change it to return nil to avoid that.

---

## Changed
split_send: changed return value to nil
