### PR TITLE
fix message#timestamp returning non-local timezone

### DIFF
--- a/lib/discordrb/data/message.rb
+++ b/lib/discordrb/data/message.rb
@@ -106,7 +106,7 @@ module Discordrb
 
       @webhook_id = data['webhook_id'].to_i if data['webhook_id']
 
-      @timestamp = Time.parse(data['timestamp']) if data['timestamp']
+      @timestamp = Time.now if data['timestamp']
       @edited_timestamp = data['edited_timestamp'].nil? ? nil : Time.parse(data['edited_timestamp'])
       @edited = !@edited_timestamp.nil?
       @id = data['id'].to_i


### PR DESCRIPTION
# Summary

Message#timestamp was returning a time that was in a specific timezone.
More specifically, `data['timestamp']` returns a non-local time, therefore my solution was to work around using this data.
I fixed this by using `Time.now` rather than `Time.parse(data['timestamp'])` in the Message class.
There is likely a better way to go about this fix, though my only goal was to fix this specific issue.

## Screenshots

[Before this change](https://imgur.com/ZBBUXSj)
[After this change](https://imgur.com/J0s1u0w)

## Changes

in discordrb/lib/discordrb/data/message.rb:
from
`@timestamp = Time.parse(data['timestamp']) if data['timestamp']`
to
`@timestamp = Time.now if data['timestamp']`

