### PR TITLE
Give up reconnection on a fatal close code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typestrings for API that accepts discord IDs is now consistently represented as `String, Integer` ([#616](https://github.com/meew0/discordrb/pull/616), thanks @swarley)
 - When a command is executed with an invalid number of arguments, the error response is sent as a single message ([#627](https://github.com/meew0/discordrb/pull/627))
 - The `#split_send` utility method returns `nil`, to avoid the case where the return value is captured in the implicit return message ([#629](https://github.com/meew0/discordrb/pull/629), thanks @captainSV)
+- Give up reconnecting after receiving a fatal close code ([#633](https://github.com/meew0/discordrb/pull/633))
 
 ### Fixed
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -784,7 +784,7 @@ module Discordrb
         LOGGER.error('The websocket connection has closed due to an error!')
         LOGGER.log_exception(e)
       else
-        LOGGER.error("The websocket connection has closed: #{e.inspect}")
+        LOGGER.error("The websocket connection has closed: #{e&.inspect || '(no information)'}")
       end
     end
 

--- a/lib/discordrb/gateway.rb
+++ b/lib/discordrb/gateway.rb
@@ -168,8 +168,19 @@ module Discordrb
       end
 
       LOGGER.debug('WS thread created! Now waiting for confirmation that everything worked')
-      sleep(0.5) until @ws_success
-      LOGGER.debug('Confirmation received! Exiting run.')
+      loop do
+        sleep(0.5)
+
+        if @ws_success
+          LOGGER.debug('Confirmation received! Exiting run.')
+          break
+        end
+
+        if @should_reconnect == false
+          LOGGER.debug('Reconnection flag was unset. Exiting run.')
+          break
+        end
+      end
     end
 
     # Prevents all further execution until the websocket thread stops (e.g. through a closed connection).
@@ -771,6 +782,12 @@ module Discordrb
       handle_close(e)
     end
 
+    # Close codes that are unrecoverable, after which we should not try to reconnect.
+    # - 4003: Not authenticated. How did this happen?
+    # - 4004: Authentication failed. Token was wrong, nothing we can do.
+    # - 4011: Sharding required. Currently requires developer intervention.
+    FATAL_CLOSE_CODES = [4003, 4004, 4011].freeze
+
     def handle_close(e)
       @bot.__send__(:raise_event, Events::DisconnectEvent.new(@bot))
 
@@ -779,6 +796,7 @@ module Discordrb
         LOGGER.error('Websocket close frame received!')
         LOGGER.error("Code: #{e.code}")
         LOGGER.error("Message: #{e.data}")
+        @should_reconnect = false if FATAL_CLOSE_CODES.include?(e.code)
       elsif e.is_a? Exception
         # Log the exception
         LOGGER.error('The websocket connection has closed due to an error!')


### PR DESCRIPTION
- Clarifies gw warning on internal close with no data

- Unsets the reconnection flag if a fatal close code is received. These are close codes that either always, or in the current state of the library, require developer intervention. Otherwise we end up spamming
the gateway forever with a connection plan that will never work.

For the most part succeeds the intent of #593.