### PR TITLE
Allow for null fields in API requests

### DIFF
--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -97,7 +97,8 @@ module Discordrb::API
     if attributes.count { |elem| elem.is_a? Hash } > 1
       payload_index = attributes.index { |elem| elem.is_a? Hash }
       payload = attributes[payload_index]
-      payload.compact!.each do |k,v|
+      payload.compact!
+      payload.each do |k,v|
         payload[k] = nil if v == :null
       end
       attributes[payload_index] = payload.to_json

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -98,7 +98,7 @@ module Discordrb::API
       payload_index = attributes.index { |elem| elem.is_a? Hash }
       payload = attributes[payload_index]
       payload.compact!
-      payload.each do |k,v|
+      payload.each do |k, v|
         payload[k] = nil if v == :null
       end
       attributes[payload_index] = payload.to_json

--- a/lib/discordrb/api.rb
+++ b/lib/discordrb/api.rb
@@ -94,6 +94,15 @@ module Discordrb::API
     # Add a custom user agent
     attributes.last[:user_agent] = user_agent if attributes.last.is_a? Hash
 
+    if attributes.count { |elem| elem.is_a? Hash } > 1
+      payload_index = attributes.index { |elem| elem.is_a? Hash }
+      payload = attributes[payload_index]
+      payload.compact!.each do |k,v|
+        payload[k] = nil if v == :null
+      end
+      attributes[payload_index] = payload.to_json
+    end
+
     # The most recent Discord rate limit requirements require the support of major parameters, where a particular route
     # and major parameter combination (*not* the HTTP method) uniquely identifies a RL bucket.
     key = [key, major_parameter].freeze

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -26,7 +26,7 @@ module Discordrb::API::Channel
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}",
-      data.to_json,
+      data,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -78,7 +78,7 @@ module Discordrb::API::Channel
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages",
-      { content: message, tts: tts, embed: embed, nonce: nonce }.to_json,
+      { content: message, tts: tts, embed: embed, nonce: nonce },
       Authorization: token,
       content_type: :json
     )
@@ -110,7 +110,7 @@ module Discordrb::API::Channel
       channel_id,
       :patch,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/#{message_id}",
-      { content: message, mentions: mentions, embed: embed }.to_json,
+      { content: message, mentions: mentions, embed: embed },
       Authorization: token,
       content_type: :json
     )
@@ -136,7 +136,7 @@ module Discordrb::API::Channel
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/messages/bulk-delete",
-      { messages: messages }.to_json,
+      { messages: messages },
       Authorization: token,
       content_type: :json
     )
@@ -217,7 +217,7 @@ module Discordrb::API::Channel
       channel_id,
       :put,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/permissions/#{overwrite_id}",
-      { type: type, id: overwrite_id, allow: allow, deny: deny }.to_json,
+      { type: type, id: overwrite_id, allow: allow, deny: deny },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -244,7 +244,7 @@ module Discordrb::API::Channel
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/invites",
-      { max_age: max_age, max_uses: max_uses, temporary: temporary, unique: unique }.to_json,
+      { max_age: max_age, max_uses: max_uses, temporary: temporary, unique: unique },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -321,7 +321,7 @@ module Discordrb::API::Channel
       nil,
       :post,
       "#{Discordrb::API.api_base}/users/#{bot_user_id}/channels",
-      {}.to_json,
+      {},
       Authorization: token,
       content_type: :json
     )
@@ -334,7 +334,7 @@ module Discordrb::API::Channel
       nil,
       :put,
       "#{Discordrb::API.api_base}/channels/#{pm_channel_id}/recipients/#{user_id}",
-      {}.to_json,
+      {},
       Authorization: token,
       content_type: :json
     )
@@ -353,7 +353,7 @@ module Discordrb::API::Channel
       nil,
       :put,
       "#{Discordrb::API.api_base}/channels/#{group_channel_id}/recipients/#{user_id}",
-      {}.to_json,
+      {},
       Authorization: token,
       content_type: :json
     )
@@ -391,7 +391,7 @@ module Discordrb::API::Channel
       channel_id,
       :post,
       "#{Discordrb::API.api_base}/channels/#{channel_id}/webhooks",
-      { name: name, avatar: avatar }.to_json,
+      { name: name, avatar: avatar },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason

--- a/lib/discordrb/api/channel.rb
+++ b/lib/discordrb/api/channel.rb
@@ -105,6 +105,7 @@ module Discordrb::API::Channel
   # Edit a message
   # https://discordapp.com/developers/docs/resources/channel#edit-message
   def edit_message(token, channel_id, message_id, message, mentions = [], embed = nil)
+    embed = :null if embed.nil?
     Discordrb::API.request(
       :channels_cid_messages_mid,
       channel_id,

--- a/lib/discordrb/api/server.rb
+++ b/lib/discordrb/api/server.rb
@@ -12,7 +12,7 @@ module Discordrb::API::Server
       nil,
       :post,
       "#{Discordrb::API.api_base}/guilds",
-      { name: name, region: region.to_s }.to_json,
+      { name: name, region: region.to_s },
       Authorization: token,
       content_type: :json
     )
@@ -38,7 +38,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}",
-      { name: name, region: region, icon: icon, afk_channel_id: afk_channel_id, afk_timeout: afk_timeout, splash: splash, default_message_notifications: default_message_notifications, verification_level: verification_level, explicit_content_filter: explicit_content_filter, system_channel_id: system_channel_id }.to_json,
+      { name: name, region: region, icon: icon, afk_channel_id: afk_channel_id, afk_timeout: afk_timeout, splash: splash, default_message_notifications: default_message_notifications, verification_level: verification_level, explicit_content_filter: explicit_content_filter, system_channel_id: system_channel_id },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -52,7 +52,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}",
-      { owner_id: user_id }.to_json,
+      { owner_id: user_id },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -91,7 +91,7 @@ module Discordrb::API::Server
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user, position: position }.to_json,
+      { name: name, type: type, topic: topic, bitrate: bitrate, user_limit: user_limit, permission_overwrites: permission_overwrites, parent_id: parent_id, nsfw: nsfw, rate_limit_per_user: rate_limit_per_user, position: position },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -106,7 +106,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/channels",
-      positions.to_json,
+      positions,
       Authorization: token,
       content_type: :json
     )
@@ -149,7 +149,7 @@ module Discordrb::API::Server
         mute: mute,
         deaf: deaf,
         channel_id: channel_id
-      }.reject { |_, v| v.nil? }.to_json,
+      },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -232,7 +232,7 @@ module Discordrb::API::Server
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/roles",
-      { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions }.to_json,
+      { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -250,7 +250,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/roles/#{role_id}",
-      { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions }.to_json,
+      { color: colour, name: name, hoist: hoist, mentionable: mentionable, permissions: packed_permissions },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -265,7 +265,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/roles",
-      roles.to_json,
+      roles,
       Authorization: token,
       content_type: :json
     )
@@ -394,7 +394,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/integrations/#{integration_id}",
-      { expire_behavior: expire_behavior, expire_grace_period: expire_grace_period, enable_emoticons: enable_emoticons }.to_json,
+      { expire_behavior: expire_behavior, expire_grace_period: expire_grace_period, enable_emoticons: enable_emoticons },
       Authorization: token,
       content_type: :json
     )
@@ -445,7 +445,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/embed",
-      { enabled: enabled, channel_id: channel_id }.to_json,
+      { enabled: enabled, channel_id: channel_id },
       Authorization: token,
       'X-Audit-Log-Reason': reason,
       content_type: :json
@@ -460,7 +460,7 @@ module Discordrb::API::Server
       server_id,
       :post,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/emojis",
-      { image: image, name: name, roles: roles }.to_json,
+      { image: image, name: name, roles: roles },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -475,7 +475,7 @@ module Discordrb::API::Server
       server_id,
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/emojis/#{emoji_id}",
-      { name: name, roles: roles }.to_json,
+      { name: name, roles: roles },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -526,7 +526,7 @@ module Discordrb::API::Server
       server_id,
       :put,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/members/#{user_id}",
-      { access_token: access_token, nick: nick, roles: roles, mute: mute, deaf: deaf }.to_json,
+      { access_token: access_token, nick: nick, roles: roles, mute: mute, deaf: deaf },
       content_type: :json,
       Authorization: token
     )

--- a/lib/discordrb/api/user.rb
+++ b/lib/discordrb/api/user.rb
@@ -35,7 +35,7 @@ module Discordrb::API::User
       server_id, # This is technically a guild endpoint
       :patch,
       "#{Discordrb::API.api_base}/guilds/#{server_id}/members/@me/nick",
-      { nick: nick }.to_json,
+      { nick: nick },
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -50,7 +50,7 @@ module Discordrb::API::User
       nil,
       :patch,
       "#{Discordrb::API.api_base}/users/@me",
-      { avatar: avatar, email: email, new_password: new_password, password: password, username: new_username }.to_json,
+      { avatar: avatar, email: email, new_password: new_password, password: password, username: new_username },
       Authorization: token,
       content_type: :json
     )
@@ -100,7 +100,7 @@ module Discordrb::API::User
       nil,
       :post,
       "#{Discordrb::API.api_base}/users/@me/channels",
-      { recipient_id: recipient_id }.to_json,
+      { recipient_id: recipient_id },
       Authorization: token,
       content_type: :json
     )
@@ -125,7 +125,7 @@ module Discordrb::API::User
       nil,
       :patch,
       "#{Discordrb::API.api_base}/users/@me/settings",
-      { status: status }.to_json,
+      { status: status },
       Authorization: token,
       content_type: :json
     )

--- a/lib/discordrb/api/webhook.rb
+++ b/lib/discordrb/api/webhook.rb
@@ -35,7 +35,7 @@ module Discordrb::API::Webhook
       webhook_id,
       :patch,
       "#{Discordrb::API.api_base}/webhooks/#{webhook_id}",
-      data.to_json,
+      data,
       Authorization: token,
       content_type: :json,
       'X-Audit-Log-Reason': reason
@@ -50,7 +50,7 @@ module Discordrb::API::Webhook
       webhook_id,
       :patch,
       "#{Discordrb::API.api_base}/webhooks/#{webhook_id}/#{webhook_token}",
-      data.to_json,
+      data,
       content_type: :json,
       'X-Audit-Log-Reason': reason
     )


### PR DESCRIPTION
# Summary
Add support for using `:null` as a null value place holder in API requests.
Also consolidates calls to `to_json` in `API::*`.

---

## Changed
`:null` is converted to `nil` after `nil` values are filtered in `API.request`

## Removed
Calls to `to_json` for payloads in `API::*`
